### PR TITLE
Start implementation of db::models::Status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_derives 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -589,6 +590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustodon"
 version = "0.1.0"
 dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_infer_schema 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Rustodon team"]
 
 [dependencies]
+chrono = "0.4"
 dotenv = "0.10"
 try_opt = "0.1"
 lazy_static = "1.0"
@@ -12,7 +13,7 @@ itertools = "0.7.4"
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "v0.3" }
 rocket_codegen = { git = "https://github.com/SergioBenitez/Rocket", branch = "v0.3" }
 
-diesel = { version = "1.0.0", features = ["postgres"] }
+diesel = { version = "1.0.0", features = ["postgres", "chrono"] }
 diesel_infer_schema = { version = "1.0.0", features = ["postgres"] }
 r2d2 = "0.8.1"
 r2d2-diesel = "1.0.0"

--- a/migrations/2018-01-08-072612_status_uri/down.sql
+++ b/migrations/2018-01-08-072612_status_uri/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE statuses DROP COLUMN uri RESTRICT;

--- a/migrations/2018-01-08-072612_status_uri/up.sql
+++ b/migrations/2018-01-08-072612_status_uri/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE statuses ADD COLUMN uri TEXT;

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -5,6 +5,8 @@
 //! you can obtain with `diesel print-schema`.
 
 use std::borrow::Cow;
+use chrono::DateTime;
+use chrono::offset::Utc;
 use diesel::prelude::*;
 use db::schema::{accounts, users, statuses, follows};
 use db::Connection;
@@ -44,6 +46,7 @@ pub struct Status {
     pub id: i64,
     pub text: String,
     pub content_warning: Option<String>,
+    pub created_at: DateTime<Utc>,
 
     pub account_id: i64,
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -14,6 +14,8 @@ use pwhash::bcrypt;
 use ::{BASE_URL, DOMAIN};
 
 /// Represents an account (local _or_ remote) on the network, storing federation-relevant information.
+///
+/// A uri of None implies a local account.
 #[derive(Identifiable, Queryable, Debug, Serialize, PartialEq)]
 #[table_name = "accounts"]
 pub struct Account {
@@ -39,6 +41,8 @@ pub struct User {
 }
 
 /// Represents a post.
+///
+/// A uri of None implies a local status.
 #[derive(Identifiable, Queryable, Associations, PartialEq, Debug)]
 #[belongs_to(Account)]
 #[table_name = "statuses"]

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -47,8 +47,8 @@ pub struct Status {
     pub text: String,
     pub content_warning: Option<String>,
     pub created_at: DateTime<Utc>,
-
     pub account_id: i64,
+    pub uri: Option<String>,
 }
 
 /// Represents a following relationship `[source user] -> [target user]`.

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -151,3 +151,26 @@ impl Account {
                                                                 user=self.username).into())
     }
 }
+
+impl Status {
+    pub fn account(&self, db_conn: &Connection) -> QueryResult<Account> {
+        use db::schema::accounts::dsl;
+        dsl::accounts
+            .find(self.account_id)
+            .get_result::<Account>(&**db_conn)
+    }
+
+    pub fn get_uri<'a>(&'a self, db_conn: &Connection) -> QueryResult<Cow<'a, str>> {
+        Ok(self.uri
+            .as_ref()
+            .map(|x| String::as_str(x).into())
+            .unwrap_or(
+                format!(
+                    "{base}/users/{user}/updates/{id}",
+                    base = BASE_URL.as_str(),
+                    user = self.account(db_conn)?.username,
+                    id = self.id
+                ).into(),
+            ))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 #[macro_use] extern crate diesel_infer_schema;
 #[macro_use] extern crate try_opt;
 #[macro_use] extern crate lazy_static;
+extern crate chrono;
 extern crate itertools;
 extern crate rocket;
 extern crate rocket_contrib;


### PR DESCRIPTION
* Adds the `created_at` column to the struct as it is already in the schema
* Adds `get_uri` in a similar style to `Account`'s; adds `account` as a convenience function that I'm sure we'll need a few more times at least

The style of `Status::get_uri` was selectively fixed up by rustfmt-nightly (I didn't apply style fixes outside my own changes). It has some very different opinions than what is currently present in the code base.