### PR TITLE
README: Make clear the assumption that ~/.cargo/bin is in your PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To set up a new database in Postgres and run all the migrations, first install t
 $ cargo install diesel_cli
 ```
 
+Cargo, by default, will install any package binaries into `~/.cargo/bin`. We will assume you have added that directory to your `PATH` environment variable.
+
 Then, run the database setup:
 ```
 $ diesel database setup


### PR DESCRIPTION
Those unfamiliar with Rust's `cargo` installation tool for libraries
and tools may not be aware that any binaries it installs will be
installed in `~/.cargo/bin`.

Making that explicit in the documentation.