### PR TITLE
Improve error handling and use Failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,11 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -50,6 +55,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cargo_metadata"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cc"
@@ -68,6 +83,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clippy"
+version = "0.0.179"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.179 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clippy_lints"
+version = "0.0.179"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -157,6 +202,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +237,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "gcc"
 version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getopts"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -219,6 +288,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "infer_schema_internals"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +320,14 @@ dependencies = [
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -413,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pwhash"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +511,11 @@ dependencies = [
  "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quine-mc_cluskey"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -591,9 +687,12 @@ name = "rustodon"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.179 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_infer_schema 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwhash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -605,7 +704,6 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "try_opt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -624,6 +722,19 @@ dependencies = [
 [[package]]
 name = "scopeguard"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -698,6 +809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tera"
 version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,11 +875,6 @@ dependencies = [
 [[package]]
 name = "traitobject"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "try_opt"
-version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -881,11 +996,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
+"checksum cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be1057b8462184f634c3a208ee35b0f935cfd94b694b26deadccd98732088d7b"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
+"checksum clippy 0.0.179 (registry+https://github.com/rust-lang/crates.io-index)" = "f3865be451fd0a4f53376171c2e86e52ef6dfa2d51e8d137229851b332f5ab12"
+"checksum clippy_lints 0.0.179 (registry+https://github.com/rust-lang/crates.io-index)" = "78002b9b809798e082008d1a90d63b1053243b0b03ded66bb4d661a6248be896"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
 "checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
@@ -896,17 +1015,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
+"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fuchsia-zircon 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd510087c325af53ba24f3be8f1c081b0982319adcb8b03cad764512923ccc19"
 "checksum fuchsia-zircon-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "08b3a6f13ad6b96572b53ce7af74543132f1a7055ccceb6d073dd36c54481859"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
+"checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum infer_schema_internals 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea8948b797ecdcfd162322c0fadece87c18eeb13b8d2a6750385f796e2d26591"
 "checksum infer_schema_macros 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb8a190a8a1cd2db92e59d62afca8e1d8a22dae9b26b753ba09067ac5835a6ae"
 "checksum isatty 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f2a233726c7bb76995cec749d59582e5664823b7245d4970354408f1d79a7a2"
+"checksum itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f2be4da1690a039e9ae5fd575f706a63ad5a2120f161b1d653c9da3930dd21"
 "checksum itertools 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "947aa0b9bb417792efa3936c5dada2d680b3bc27ea6a88ffa062f4c4d86ef8c5"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -931,7 +1055,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pest 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e823a5967bb4cdc6d3e46f47baaf4ecfeae44413a642b74ad44e59e49c7f6"
 "checksum pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dfb5e575ef93a1b7b2a381d47ba7c5d4e4f73bff37cee932195de769aad9a54"
+"checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
 "checksum pwhash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e13b76f7965ed95c1dfe1f5eb5607d12de34af86140212dde3defa15c8ccbe0f"
+"checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f9078ca6a8a5568ed142083bb2f7dc9295b69d16f867ddcc9849e51b17d8db46"
 "checksum r2d2-diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9c29bad92da76d02bc2c020452ebc3a3fe6fa74cfab91e711c43116e4fb1a3"
@@ -952,6 +1078,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a2ff3fc5223829be817806c6441279c676e454cc7da608faf03b0ccc09d3889"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
 "checksum serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ba7591cfe93755e89eeecdbcc668885624829b020050e6aec99c2a03bd3fd0"
 "checksum serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e03f1c9530c3fb0a0a5c9b826bdd9246a5921ae995d75f512ac917fc4dd55b5"
@@ -961,13 +1089,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum state 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "acc74e29126a281afcfd8dfa0ae83f1720a1adf5fc99524898e45ca440a73919"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tera 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d706c3bec8103f346fc7b8a3887a2ff4195cf704bdbc6307069f32ea8a2b3af5"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-"checksum try_opt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d30b71e7ba40551f9873f3ba9f4ee36f16015adf0962aba57caf403088370db1"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ authors = ["The Rustodon team"]
 [dependencies]
 chrono = "0.4"
 dotenv = "0.10"
-try_opt = "0.1"
+failure = "0.1.1"
+failure_derive = "0.1.1"
 lazy_static = "1.0"
 itertools = "0.7.4"
 

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -16,8 +16,8 @@ use {BASE_URL, DOMAIN};
 
 /// Type representing the result of a database operation.
 ///
-/// The nested `Option<T>` in the `Result` allows a semantic distinction bewteen "query error"
-/// and "no records returned".
+/// The nested `Option<T>` in the `Result` allows a semantic distinction
+/// bewteen "query error" and "no records returned".
 type DatabaseResult<T> = Result<Option<T>, DieselError>;
 
 /// Represents an account (local _or_ remote) on the network, storing federation-relevant information.

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -93,10 +93,10 @@ impl User {
         });
 
         use db::schema::users::dsl;
-        Ok(dsl::users
+        dsl::users
             .filter(dsl::account_id.eq(account.id))
             .first::<User>(&**db_conn)
-            .optional()?)
+            .optional()
     }
 }
 
@@ -110,11 +110,11 @@ impl Account {
         S: Into<String>,
     {
         use db::schema::accounts::dsl;
-        Ok(dsl::accounts
+        dsl::accounts
             .filter(dsl::username.eq(username.into()))
             .filter(dsl::domain.is_null())
             .first::<Account>(&**db_conn)
-            .optional()?)
+            .optional()
     }
 
     pub fn fully_qualified_username(&self) -> String {

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -8,10 +8,17 @@ use std::borrow::Cow;
 use chrono::DateTime;
 use chrono::offset::Utc;
 use diesel::prelude::*;
+use pwhash::bcrypt;
 use db::schema::{accounts, follows, statuses, users};
 use db::Connection;
-use pwhash::bcrypt;
+use diesel::result::Error as DieselError;
 use {BASE_URL, DOMAIN};
+
+/// Type representing the result of a database operation.
+///
+/// The nested `Option<T>` in the `Result` allows a semantic distinction bewteen "query error"
+/// and "no records returned".
+type DatabaseResult<T> = Result<Option<T>, DieselError>;
 
 /// Represents an account (local _or_ remote) on the network, storing federation-relevant information.
 ///
@@ -81,41 +88,36 @@ impl User {
         bcrypt::hash(&password.into()).expect("Couldn't hash password!")
     }
 
-    // TODO: should probably be Result<Option<T>>?
-    // requires a bit of thought, because we can't just try_opt! then :(
-    pub fn by_username(db_conn: &Connection, username: String) -> Option<User> {
-        let account = try_opt!({
+    pub fn by_username(db_conn: &Connection, username: String) -> DatabaseResult<User> {
+        let account = try_resopt!({
             use db::schema::accounts::dsl;
             dsl::accounts
                 .filter(dsl::username.eq(username))
                 .filter(dsl::domain.is_null())
                 .first::<Account>(&**db_conn)
                 .optional()
-                .unwrap()
         });
 
         use db::schema::users::dsl;
-        dsl::users
+        Ok(dsl::users
             .filter(dsl::account_id.eq(account.id))
             .first::<User>(&**db_conn)
-            .optional()
-            .unwrap()
+            .optional()?)
     }
 }
 
 impl Account {
     // TODO: result
-    pub fn fetch_local_by_username<S>(db_conn: &Connection, username: S) -> Option<Account>
+    pub fn fetch_local_by_username<S>(db_conn: &Connection, username: S) -> DatabaseResult<Account>
     where
         S: Into<String>,
     {
         use db::schema::accounts::dsl;
-        dsl::accounts
+        Ok(dsl::accounts
             .filter(dsl::username.eq(username.into()))
             .filter(dsl::domain.is_null())
             .first::<Account>(&**db_conn)
-            .optional()
-            .unwrap()
+            .optional()?)
     }
 
     pub fn fully_qualified_username(&self) -> String {
@@ -201,24 +203,25 @@ impl Account {
 }
 
 impl Status {
-    pub fn account(&self, db_conn: &Connection) -> QueryResult<Account> {
+    pub fn account(&self, db_conn: &Connection) -> DatabaseResult<Account> {
         use db::schema::accounts::dsl;
         dsl::accounts
             .find(self.account_id)
-            .get_result::<Account>(&**db_conn)
+            .first::<Account>(&**db_conn)
+            .optional()
     }
 
-    pub fn get_uri<'a>(&'a self, db_conn: &Connection) -> QueryResult<Cow<'a, str>> {
-        Ok(self.uri
+    pub fn get_uri<'a>(&'a self, db_conn: &Connection) -> DatabaseResult<Cow<'a, str>> {
+        Ok(Some(self.uri
             .as_ref()
             .map(|x| String::as_str(x).into())
             .unwrap_or(
                 format!(
                     "{base}/users/{user}/updates/{id}",
                     base = BASE_URL.as_str(),
-                    user = self.account(db_conn)?.username,
+                    user = try_resopt!(self.account(db_conn)).username,
                     id = self.id
                 ).into(),
-            ))
+            )))
     }
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -212,16 +212,18 @@ impl Status {
     }
 
     pub fn get_uri<'a>(&'a self, db_conn: &Connection) -> DatabaseResult<Cow<'a, str>> {
-        Ok(Some(self.uri
-            .as_ref()
-            .map(|x| String::as_str(x).into())
-            .unwrap_or(
-                format!(
-                    "{base}/users/{user}/updates/{id}",
-                    base = BASE_URL.as_str(),
-                    user = try_resopt!(self.account(db_conn)).username,
-                    id = self.id
-                ).into(),
-            )))
+        Ok(Some(
+            self.uri
+                .as_ref()
+                .map(|x| String::as_str(x).into())
+                .unwrap_or(
+                    format!(
+                        "{base}/users/{user}/updates/{id}",
+                        base = BASE_URL.as_str(),
+                        user = try_resopt!(self.account(db_conn)).username,
+                        id = self.id
+                    ).into(),
+                ),
+        ))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,20 @@
-use diesel;
+/// A type which could be nonexistent, existent, or errored.
+/// Useful for routes which might return {something, a 404, a 500}.
+pub type OptionalResult<T> = Result<Option<T>, ::failure::Error>;
 
-enum Error {
-    DBError(diesel::result::Error),
-}
-
-impl From<diesel::result::Error> for Error {
-    fn from(err: diesel::result::Error) -> Error {
-        Error::DBError(err)
-    }
+/// An analog of `try!` for `OptionalResult`s.
+macro_rules! try_resopt {
+    ($expr:expr) => (match $expr {
+        ::std::result::Result::Ok(opt_val) => {
+            match opt_val {
+                ::std::option::Option::Some(val) => val,
+                ::std::option::Option::None => {
+                    return ::std::result::Result::Ok(::std::option::Option::None);
+                }
+            }
+        },
+        ::std::result::Result::Err(err) => {
+            return ::std::result::Result::Err(::std::convert::From::from(err));
+        }
+    })
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
-/// A type which could be nonexistent, existent, or errored.
-/// Useful for routes which might return {something, a 404, a 500}.
-pub type OptionalResult<T> = Result<Option<T>, ::failure::Error>;
+/// A type which could be nonexistent, existent, or errored;
+/// used for routes which might return {something, a 404, a 500}.
+pub type Perhaps<T> = Result<Option<T>, ::failure::Error>;
 
-/// An analog of `try!` for `OptionalResult`s.
+/// An analog of `try!` for `Result<Option<_>, _>`s.
 macro_rules! try_resopt {
     ($expr:expr) => (match $expr {
         ::std::result::Result::Ok(opt_val) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
+#[macro_use]
 mod error;
 mod db;
 mod routes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@
 #![plugin(rocket_codegen)]
 #![recursion_limit = "128"]
 
+extern crate failure;
+#[macro_use] extern crate failure_derive;
 extern crate chrono;
 #[macro_use]
 extern crate diesel;
@@ -21,8 +23,6 @@ extern crate serde;
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
-#[macro_use]
-extern crate try_opt;
 
 mod error;
 mod db;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,15 @@
 #![plugin(rocket_codegen)]
 #![recursion_limit = "128"]
 
-extern crate failure;
-#[macro_use] extern crate failure_derive;
 extern crate chrono;
 #[macro_use]
 extern crate diesel;
 #[macro_use]
 extern crate diesel_infer_schema;
 extern crate dotenv;
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 extern crate itertools;
 #[macro_use]
 extern crate lazy_static;

--- a/src/routes/ap.rs
+++ b/src/routes/ap.rs
@@ -7,7 +7,7 @@ use rocket_contrib::Json;
 
 use db;
 use db::models::Account;
-use error::OptionalResult;
+use error::Perhaps;
 use activitypub::{ActivityStreams, AsActivityPub};
 use BASE_URL;
 
@@ -47,7 +47,7 @@ pub fn ap_user_object(
     username: String,
     _ag: ActivityGuard,
     db_conn: db::Connection,
-) -> OptionalResult<ActivityStreams> {
+) -> Perhaps<ActivityStreams> {
     Ok(Account::fetch_local_by_username(&db_conn, username)?.map(|acct| acct.as_activitypub()))
 }
 
@@ -57,10 +57,7 @@ pub struct WFQuery {
 }
 
 #[get("/.well-known/webfinger?<query>")]
-pub fn webfinger_get_resource(
-    query: WFQuery,
-    db_conn: db::Connection,
-) -> OptionalResult<Content<Json>> {
+pub fn webfinger_get_resource(query: WFQuery, db_conn: db::Connection) -> Perhaps<Content<Json>> {
     // TODO: don't unwrap
     let (_, addr) = query
         .resource

--- a/src/routes/ap.rs
+++ b/src/routes/ap.rs
@@ -48,8 +48,7 @@ pub fn ap_user_object(
     _ag: ActivityGuard,
     db_conn: db::Connection,
 ) -> OptionalResult<ActivityStreams> {
-    Ok(Account::fetch_local_by_username(&db_conn, username)?
-        .map(|acct| acct.as_activitypub()))
+    Ok(Account::fetch_local_by_username(&db_conn, username)?.map(|acct| acct.as_activitypub()))
 }
 
 #[derive(FromForm, Debug)]
@@ -58,7 +57,10 @@ pub struct WFQuery {
 }
 
 #[get("/.well-known/webfinger?<query>")]
-pub fn webfinger_get_resource(query: WFQuery, db_conn: db::Connection) -> OptionalResult<Content<Json>> {
+pub fn webfinger_get_resource(
+    query: WFQuery,
+    db_conn: db::Connection,
+) -> OptionalResult<Content<Json>> {
     // TODO: don't unwrap
     let (_, addr) = query
         .resource

--- a/src/routes/ui.rs
+++ b/src/routes/ui.rs
@@ -3,14 +3,14 @@ use rocket_contrib::Template;
 
 use db;
 use db::models::Account;
-use error::OptionalResult;
+use error::Perhaps;
 
 pub fn routes() -> Vec<Route> {
     routes![index, user_page]
 }
 
 #[get("/users/<username>", format = "text/html")]
-pub fn user_page(username: String, db_conn: db::Connection) -> OptionalResult<Template> {
+pub fn user_page(username: String, db_conn: db::Connection) -> Perhaps<Template> {
     let account = try_resopt!(Account::fetch_local_by_username(&db_conn, username));
 
     // We can use a cute hack to remove the need to explicitly write out a context struct,

--- a/src/routes/ui.rs
+++ b/src/routes/ui.rs
@@ -1,15 +1,17 @@
 use rocket::Route;
 use rocket_contrib::Template;
+
 use db;
 use db::models::Account;
+use error::OptionalResult;
 
 pub fn routes() -> Vec<Route> {
     routes![index, user_page]
 }
 
 #[get("/users/<username>", format = "text/html")]
-pub fn user_page(username: String, db_conn: db::Connection) -> Option<Template> {
-    let account = try_opt!(Account::fetch_local_by_username(&db_conn, username));
+pub fn user_page(username: String, db_conn: db::Connection) -> OptionalResult<Template> {
+    let account = try_resopt!(Account::fetch_local_by_username(&db_conn, username));
 
     // We can use a cute hack to remove the need to explicitly write out a context struct,
     // by using the serde_json helper to construct a `Serialize`-able struct on the fly.
@@ -20,7 +22,7 @@ pub fn user_page(username: String, db_conn: db::Connection) -> Option<Template> 
         "bio": account.summary.as_ref().map(String::as_str).unwrap_or("<p></p>"),
     });
 
-    Some(Template::render("user_profile", context))
+    Ok(Some(Template::render("user_profile", context)))
 }
 
 #[get("/")]

--- a/src/routes/ui.rs
+++ b/src/routes/ui.rs
@@ -24,6 +24,6 @@ pub fn user_page(username: String, db_conn: db::Connection) -> Option<Template> 
 }
 
 #[get("/")]
-pub fn index(db_conn: db::Connection) -> Template {
+pub fn index() -> Template {
     Template::render("index", json!({}))
 }


### PR DESCRIPTION
- [x] Alias a type `OptionalResult<T> = Result<Option<T>, failure::Error>` to use in route handlers.
  - [x] Design an analog of `try!` for this, (and other nested `Result<Option<_>, _>` types), `try_resopt!`.
- [x] Refactor database helpers to return `Result<Option<_>, DieselError>`, using `try_resopt!` to help accomplish this.
- [x] Refactor routes to return `OptionalResult<_>`, using `try_resopt!` to help fail database accesses through.