### PR TITLE
Enable AWS CodeDeploy to our project's CD server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,11 @@ before_install:
   - sudo apt-get install -yqq libpq-dev
 
 env:
-  - MIGRATION_DIR=migrations FEATURES=postgres DATABASE_URL=postgres://postgres@localhost/rustodon
+  global:
+    - secure: "kn3n05rK2nrLsMrUXCNqCiYtd3plpwfQSrSAkNFuI7A22RHmC2ItvpR01rT++MfR2CPkTlDHt5ONHkbOfDKUGF1seakNokdK6Kj9q/AtnOPW0wGc7XN31BqYS9JNqjoNwLM3/ETJj6JAneoIP+hglzrOiCSzgyoy/BHNQMqIvlw4GhAX3baK/2HsrQqMIHP+IKpObPbvkP3KXtSepbevZhUWdRrqnU18QHV3ZZqXLiVMPXcjb9ulRKkzisP5qVAgyVpmVke0YMV8B0OmXcsGjNQ41lQvluVghvhxOLvjga7qPLZIJ98aoX5ylGSdY7EhHRUjrq/N1je5FeuXgMAMzqaUeJ1CmkdOEFm/7y6kcLnJnJ7206ATWIYx56mYITGNMjyC9p98HIgb3W+E+Lj5X/RNGTcpDx6cmr61hsEk+eRjcbzReMk/6ukmTzqyxBEM8C5s2OeSl30BPJZgZQk7Ahc9SJ/FK3Pi6IuBy50RfnU2CdMaCFip0tg5G1K6kYVUTePKNDavfLZuauYhQgc17B4eXiIUj/Hs2FYlK0FAsJqvBayL0KDqakjFnS2bnz/PZShJJkE8BKWXgVdBPwZ8jSv9Wh31zKBWn4gIRiC7u5bOL0Bqhti7tz9KAVaBJxkDuZPhJgFmuPwR5lsnq/2MOQwlKkhMMGGrEveDhorJdzE="
+    - secure: "BiPfzjONdUm99KHn2T9ezNrU38uDXAQwGh1lpm4IlLkjZ7mr1SLDQ6bE/a/2vohqZwiQ1b0A0x7aCFXZqGgMH3gwJHeQG8UOSPgKDfzZiheOazSuO7ZdeSJyqVw0JjucqzdFpAEMYVxz0tIeGFcXpMtNdCLQaa+muC3zA6SZgdYCW/8lLYGJSuaiwJJ1NocbtxRDqAeVbPXKZ/w7bODJGui3IFK48Cmh1PweKkR7J79gTS2xEKdvGUoKErvxNR34WcwFqjRbE+qhHKnZEdDqg8gaa6GkKKLXKYj0B51VkvHx2AqIlTEChPUf9t0tBzZneIh7KMbW7uM7nmI0So74TiXgd0voM6r9fGLOX3UgYdEQa2QcmT7oCWmkq8WH38zxsv4gqkpK43fC1DUsc+Wa5ap3mTaepysbOA5jMu1vwu+fNv9EdJV6iKd+eOtBDbxqgY9i+Mj27X0qyN0Nq7KXcpsBco9b36yTo/3griUd1aNFIhDYDJY7d2F1LXZs0DwMf0UP/7BE/uVVVr7jnkZ0737v+S/dZHC/BIOZYsMgH2M62r8PCPuFaIRfyhMvAcBeAw4+0bPNrxgucaaBTBmQHY/Ux1F2KTGrLN/YJ1LPGm2QCn6oF+pvQsrSxPPZ0g4ZZBvCTaQNEdRnFIgNNKtsGkCvdJ6iAYbWA+l4iIPrwOw="
+  matrix:
+    - MIGRATION_DIR=migrations FEATURES=postgres DATABASE_URL=postgres://postgres@localhost/rustodon
 
 before_script:
   - which cargo-install-update || cargo install cargo-update
@@ -24,3 +28,15 @@ script:
   - cargo fmt -- --write-mode=diff
   - diesel database setup --migration-dir=${MIGRATION_DIR}
   - cargo build --release
+
+deploy:
+  - provider: s3
+    bucket: buildartifacts.glitch.social
+    skip_cleanup: true
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    all_branches: true
+    upload-dir: rustodon
+    region: ca-central-1
+    on:
+      branch: codedeploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ script:
   - cargo fmt -- --write-mode=diff
   - diesel database setup --migration-dir=${MIGRATION_DIR}
   - cargo build --release
+  - zip -r latest *
+  - mkdir -p buildartifacts
+  - mv latest.zip buildartifacts/latest.zip
+
 
 deploy:
   - provider: s3
@@ -38,5 +42,16 @@ deploy:
     all_branches: true
     upload-dir: rustodon
     region: ca-central-1
-    on:
+    on: &2
       branch: codedeploy
+    local_dir: buildartifacts
+  - provider: codedeploy
+    bucket: buildartifacts.glitch.social
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    key: rustodon/latest.zip
+    bundle_type: zip
+    application: rustodon
+    deployment-group: rustodon-continuousdelivery
+    region: ca-central-1
+    on: *2

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ deploy:
     all_branches: true
     upload-dir: rustodon
     region: ca-central-1
-    on: &2
-      branch: codedeploy
     local_dir: buildartifacts
   - provider: codedeploy
     bucket: buildartifacts.glitch.social
@@ -54,4 +52,3 @@ deploy:
     application: rustodon
     deployment-group: rustodon-continuousdelivery
     region: ca-central-1
-    on: *2

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,7 @@
+version: 0.0
+
+os: linux
+
+files:
+  - source: ./
+    destination: /home/ubuntu/rustodon

--- a/appspec.yml
+++ b/appspec.yml
@@ -4,4 +4,4 @@ os: linux
 
 files:
   - source: ./
-    destination: /home/ubuntu/rustodon
+    destination: /srv/rustodon

--- a/appspec.yml
+++ b/appspec.yml
@@ -5,3 +5,11 @@ os: linux
 files:
   - source: ./
     destination: /srv/rustodon
+
+hooks:
+  AfterInstall:
+    - location: scripts/deploy.sh
+  ApplicationStop:
+    - location: scripts/staging_stop.sh
+  ApplicationStart:
+    - location: scripts/staging_start.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+diesel migration run

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-diesel migration run
+cd /srv/rustodon
+/root/.cargo/bin/diesel migration run

--- a/scripts/initd_rustodon
+++ b/scripts/initd_rustodon
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# Init file for rustodon
+#
+# description: A Mastodon-compatible, ActivityPub-speaking server in Rust
+
+### BEGIN INIT INFO
+# Provides:          rustodon
+# Required-Start:    $all
+# Required-Stop:     $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: rustodon
+# Description:       A Mastodon-compatible, ActivityPub-speaking server in Rust
+### END INIT INFO
+
+
+# Quick start-stop-daemon example, derived from Debian /etc/init.d/ssh
+set -e
+
+# Must be a valid filename
+NAME=rustodon
+# This will store the process id of any running service
+PIDFILE=/var/run/$NAME.pid
+#This is the command to be run, give the full pathname
+DAEMON_CWD=/srv/rustodon
+# This is the program that invokes the service
+DAEMON="/srv/rustodon/target/release/rustodon"
+# These are commandline args. They should reflect your environment needs.
+DAEMON_OPTS="run"
+
+export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
+
+case "$1" in
+  start)
+	echo -n "Starting daemon: "$NAME
+	# -m creates the pidfile becaus AFAICT Rustodon cannot do that itself
+	# -b forces the program into the background because Rustodon doesn't automatically do that.
+	# /usr/bin/env is used to set the environment variable Rocket needs to set an environment
+	start-stop-daemon -m -b --start --quiet --pidfile $PIDFILE --chdir $DAEMON_CWD --exec /usr/bin/env ROCKET_ENV=staging $DAEMON -- $DAEMON_OPTS
+        echo "."
+	;;
+  stop)
+        echo -n "Stopping daemon: "$NAME
+	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+        echo "."
+	;;
+  restart)
+        echo -n "Restarting daemon: "$NAME
+	start-stop-daemon --stop --quiet --oknodo --retry 30 --pidfile $PIDFILE
+	start-stop-daemon -m -b --start --quiet --pidfile $PIDFILE --chdir $DAEMON_CWD --exec /usr/bin/env ROCKET_ENV=staging $DAEMON -- $DAEMON_OPTS
+	echo "."
+	;;
+
+  *)
+	echo "Usage: "$0" {start|stop|restart}"
+	exit 1
+esac
+
+exit 0

--- a/scripts/staging_start.sh
+++ b/scripts/staging_start.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+service rustodon start

--- a/scripts/staging_stop.sh
+++ b/scripts/staging_stop.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+service rustodon stop


### PR DESCRIPTION
I have created a Continuous Deployment server over at http://rustodon.glitchsocial. (Note it's http only right now, easy to make it SSL but figure I'll wait until we have uptake)

This merge configures travis.yml to invoke AWS CodeDeploy to push out the latest successful master build of Rustodon over to it, and run migrations. You can see the scripts that run for deployment, they have been added.

(The deployment server is a lightly configured at the moment, but I don't think I will require any more modifications to the codebase to make the deployment process more robust.)