### PR TITLE
Remove derive_builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,25 +145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_builder"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "derive_builder_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "diesel"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,7 +704,6 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.183 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_builder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1026,8 +1006,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
 "checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
-"checksum derive_builder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c998e6ab02a828dd9735c18f154e14100e674ed08cb4e1938f0e4177543f439"
-"checksum derive_builder_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "735e24ee9e5fa8e16b86da5007856e97d592e11867e45d76e0c0d0a164a0b757"
 "checksum diesel 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925325c57038f2f14c0413bdf6a92ca72acff644959d0a1a9ebf8d19be7e9c01"
 "checksum diesel_derives 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28e2b2605ac6a3b9a586383f5f8b2b5f1108f07a421ade965b266289d2805e79"
 "checksum diesel_infer_schema 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd41decf55679a8486a3ea5e5de20e8f2a48c76d57177cd05f37f4d166f48647"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ failure_derive = "0.1.1"
 lazy_static = "1.0"
 itertools = "0.7.4"
 resopt = { path = "lib/resopt/" }
-derive_builder = "0.5.1"
 
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "v0.3" }
 rocket_codegen = { git = "https://github.com/SergioBenitez/Rocket", branch = "v0.3" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@
 #![recursion_limit = "128"]
 
 extern crate chrono;
-#[macro_use]
-extern crate derive_builder;
 extern crate dotenv;
 extern crate failure;
 #[macro_use]

--- a/src/routes/ui.rs
+++ b/src/routes/ui.rs
@@ -1,11 +1,11 @@
 use std::path::{Path, PathBuf};
 use rocket::Route;
 use rocket::response::NamedFile;
-use maud::{html, Markup, PreEscaped};
+use maud::{html, PreEscaped};
 
 use db;
 use db::models::Account;
-use templates::{Page, PageBuilder};
+use templates::Page;
 use error::Perhaps;
 
 pub fn routes() -> Vec<Route> {
@@ -16,7 +16,7 @@ pub fn routes() -> Vec<Route> {
 pub fn user_page(username: String, db_conn: db::Connection) -> Perhaps<Page> {
     let account = try_resopt!(Account::fetch_local_by_username(&db_conn, username));
 
-    let rendered = PageBuilder::default()
+    let rendered = Page::new()
         .title(format!("@{user}", user = account.username))
         .content(html! {
             div.h-card {
@@ -36,27 +36,22 @@ pub fn user_page(username: String, db_conn: db::Connection) -> Perhaps<Page> {
                     }
                 }
             }
-        })
-        .build()
-        .unwrap(); // note: won't panic since content is provided.
+        });
 
     Ok(Some(rendered))
 }
 
 #[get("/")]
 pub fn index() -> Page {
-    PageBuilder::default()
-        .content(html! {
-            h1 "Rustodon"
+    Page::new().content(html! {
+        h1 "Rustodon"
 
-            div {
-                a href="/auth/sign_in" "sign in!"
-                " | "
-                a href="/auth/sign_up" "sign up?"
-            }
-        })
-        .build()
-        .unwrap() // note: won't panic since content is provided.
+        div {
+            a href="/auth/sign_in" "sign in!"
+            " | "
+            a href="/auth/sign_up" "sign up?"
+        }
+    })
 }
 
 #[get("/static/<path..>")]

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -1,16 +1,36 @@
 use maud::{self, html, Markup, Render};
-use rocket::request::{FlashMessage, Request};
-use rocket::response::{self, Responder, Response};
+use rocket::request::Request;
+use rocket::response::{self, Responder};
 use GIT_REV;
 
 /// Type to store data about a templated page in. Used to insert each page's markup into
 /// a base template which sets up stuff like stylesheets and the general html structure.
-#[derive(Debug, Builder)]
-#[builder(setter(into))]
+#[derive(Debug, Default)]
 pub struct Page {
-    #[builder(default = "None")]
-    title: Option<String>,
-    content: Markup,
+    title:   Option<String>,
+    content: Option<Markup>,
+}
+
+impl Page {
+    pub fn new() -> Self {
+        Self {
+            title:   None,
+            content: None,
+        }
+    }
+
+    pub fn title<S>(mut self, title: S) -> Self
+    where
+        S: Into<String>,
+    {
+        self.title = Some(title.into());
+        self
+    }
+
+    pub fn content(mut self, content: Markup) -> Self {
+        self.content = Some(content);
+        self
+    }
 }
 
 /// Allows returning `Page`s from Rocket routes.
@@ -44,7 +64,9 @@ impl Render for Page {
 
             body {
                 main {
-                    (self.content)
+                    @if let Some(content) = self.content.as_ref() {
+                        (content)
+                    }
                 }
 
                 footer {


### PR DESCRIPTION
`derive_builder` is _extremely_ nice, but not flexible enough (at the moment) to specify the difference between an `String` field that is optional and settable with a string (`.field(value: Into<String>)`), and an `String` field that is optional and settable with an `Option<String>` (`.field(value: Option<Into<String>>)`).

By getting rid of `derive_builder`, I was also able to put all the Builder behavior directly on `Page`, which actually ends up being much more ergonomic. I also made page content optional, to avoid having to build and validate Builder chains, like with `derive_builder`.

Before:
```rust
let page = PageBuilder::default()
    .title("foo")
    .content(html! { p "foo" })
    .build()
    .unwrap();
```

This PR:
```rust
let page = Page::new()
    .title("foo")
    .content(html! { p "foo" });
```