### PR TITLE
fix installation method on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This environment variable could alternatively be added to the `.env` file (you c
 
 On some operating systems, you may need to separately install the Postgres client library, as well as the MySQL library (even if we won't ever use it):
 
-* Debian/Ubuntu: `apt install libpq-dev libmysqlclient-dev`
+* Ubuntu: `apt install libpq-dev libmysqlclient-dev`
+* Debian: `apt install libpq-dev default-libmysqlclient-dev`
 
 Sass/SCSS is used to make stylesheeting a bit nicer, so you'll have to install Ruby via your favourite method and `gem install sass`.
 


### PR DESCRIPTION
Fix installation method on Debian.

[Reference](https://www.linuxquestions.org/questions/linux-newbie-8/apt-get-install-mysql-server-mysql-clinet-libmysqlclient-dev-4175607306/)