### PR TITLE
Profile edit link refactor

### DIFF
--- a/style/_profile.scss
+++ b/style/_profile.scss
@@ -13,6 +13,10 @@
   border-left: 2px solid $border_color;
 }
 
+.h-card .action-edit-note {
+  margin-left: 1.5em;
+}
+
 .status {
   margin: 1em 0;
 }


### PR DESCRIPTION
Closes #50.

Link users to their profile instead of the edit form; link the edit form on their profile page.