### PR TITLE
Generate Rocket.toml at setup time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .sass-cache/
 static/style.css
 static/style.css.map
+Rocket.toml

--- a/scripts/setup
+++ b/scripts/setup
@@ -107,6 +107,25 @@ fi
 infoMsg "Running migrations..."
 diesel database setup --migration-dir=migrations
 
+if [ ! -f "Rocket.toml" ]; then
+  infoMsg "Generating Rocket.toml. This contains your server secret key, keep this file private."
+  cat <<-EOTOML > Rocket.toml
+[development]
+address = "localhost"
+port = 8000
+workers = 1
+log = "normal"
+secret_key = "$(openssl rand -base64 32)"
+
+[production]
+address = "0.0.0.0"
+port = 8000
+workers = 12
+log = "normal"
+secret_key = "$(openssl rand -base64 32)"
+EOTOML
+fi
+
 # Setup complete
 infoMsg "Setup is complete, you may run the server with:"
 echo "bundle exec foreman start"


### PR DESCRIPTION
This PR fixes #27.

Following the advice mentioned in #27, this PR uses the `scripts/setup` bootstrap to create a `Rocket.toml` file that will allow for a persistent secret across server restarts. It also prevents that file from being added to source control.