### PR TITLE
Bundle install into vendor rather than potentially in system gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 static/style.css
 static/style.css.map
 Rocket.toml
+/.bundle
+/vendor

--- a/scripts/setup
+++ b/scripts/setup
@@ -89,7 +89,7 @@ if ! which bundler 2>/dev/null 1>&2 ; then
 fi
 if ! bundle check 2>/dev/null 1>&2 ; then
   infoMsg "Installing Ruby dependencies..."
-  bundle install
+  bundle install --path=vendor/
 fi
 
 # Diesel CLI install


### PR DESCRIPTION
Some Ruby setups will take a `bundle install` and attempt to instally globally, requiring `sudo` permissions. This PR changes it such that `bundle install` happens inside the project, requiring only local perms. cc @yipdw 