### PR TITLE
Cucumber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ static/style.css.map
 Rocket.toml
 /.bundle
 /vendor
+log

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source "https://rubygems.org"
 
-gem "sass"
 
 group "development" do
+  gem "sass"
   gem "foreman"
+  gem "cucumber"
+  gem "capybara-selenium"
+  gem "minitest"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,79 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    backports (3.11.3)
+    builder (3.2.3)
+    capybara (3.3.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    cucumber (3.1.1)
+      builder (>= 2.1.2)
+      cucumber-core (~> 3.1.0)
+      cucumber-expressions (~> 6.0.0)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (3.1.0)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (>= 5.0.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
+    diff-lcs (1.3)
     ffi (1.9.23)
     foreman (0.84.0)
       thor (~> 0.19.1)
+    gherkin (5.1.0)
+    mini_mime (1.0.0)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    multi_json (1.13.1)
+    multi_test (0.1.2)
+    nokogiri (1.8.3)
+      mini_portile2 (~> 2.3.0)
+    public_suffix (3.0.2)
+    rack (2.0.5)
+    rack-test (1.0.0)
+      rack (>= 1.0, < 3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rubyzip (1.2.1)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    selenium-webdriver (3.13.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     thor (0.19.4)
+    xpath (3.1.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara-selenium
+  cucumber
   foreman
+  minitest
   sass
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/features/content/basic.feature
+++ b/features/content/basic.feature
@@ -1,5 +1,41 @@
 Feature: Basic Functionality
-  
-  Scenario:
+
+  Scenario: Visit homepage
     When I visit the homepage
     Then I should see "Rustodon"
+
+  Scenario: Signup
+    When I visit the signup page
+    And I fill in the signup form with the username "test", password "test" and email "test@test.org"
+    And I submit the signup form
+    Then I should see "signed up!"
+
+  Scenario: My user page
+    Given I am the user "test_user"
+    And I visit the user profile page for "test_user"
+    Then I should see "test_user"
+
+  Scenario: Changing my bio
+    Given I am the user "test_user"
+    And I have the bio "awoo"
+    And I visit the user profile page for "test_user"
+    Then I should see "awoo"
+
+  Scenario: Mentions in bio
+    Given the user "other_user" exists
+    And I am the user "test_user"
+    And I have the bio "@other_user exists"
+    And I visit the user profile page for "test_user"
+    Then I should see a link to the profile for "other_user" in ".p-note"
+
+  Scenario: Links in bio
+    Given I am the user "test_user"
+    And I have the bio "Signed up at http://glitch.social"
+    And I visit the user profile page for "test_user"
+    Then I should see a link to "http://glitch.social" in ".p-note"
+
+  Scenario: HTML escaped in bio
+    Given I am the user "test_user"
+    And I have the bio "<script type='text/javascript'>alert('malicious');</script>"
+    And I visit the user profile page for "test_user"
+    Then I should not see a "script" tag in ".p-note"

--- a/features/content/basic.feature
+++ b/features/content/basic.feature
@@ -1,0 +1,5 @@
+Feature: Basic Functionality
+  
+  Scenario:
+    When I visit the homepage
+    Then I should see "Rustodon"

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -1,3 +1,77 @@
-Then /I should see "([^"]+)"/ do |content|
+Then /^I should see "([^"]+)"$/ do |content|
   assert_includes(page.body, content)
+end
+
+When /^I fill in the signup form with the username "([^"]+)", password "([^"]+)" and email "([^"]+)"$/ do |username, password, email|
+  fill_in "username", with: username
+  fill_in "email", with: email
+  fill_in "password", with: password
+end
+
+When /^I fill in the login form with the username "([^"]+)" and password "([^"]+)"$/ do |username, password|
+  fill_in "username", with: username
+  fill_in "password", with: password
+end
+
+When /^I submit the signup form$/ do
+  find("form#signup button[type='submit']").click
+end
+
+When /^I submit the login form$/ do
+  find("form#signin button[type='submit']").click
+end
+
+When /^I login with username "([^"]+)" and password "([^"]+)"$/ do |username, password|
+  step %Q{I visit the signin page}
+  step %Q{I fill in the login form with the username "#{username}" and password "#{password}"}
+  step %Q{I submit the login form}
+end
+
+Given /^I am the user "([^"]+)"$/ do |username|
+  step %Q{the user "#{username}" exists}
+  step %Q{I login with username "#{username}" and password "password"}
+end
+
+Given /^the user "([^"]+)" exists$/ do |username|
+  step %Q{I visit the signup page}
+  step %Q{I fill in the signup form with the username "#{username}", password "password" and email "#{username}@test.org"}
+  step %Q{I submit the signup form}
+end
+
+When /^I fill in the biography form with "([^"]+)"/ do |bio|
+  fill_in "summary", with: bio
+end
+
+When /^I submit the biography form$/ do
+  click_link_or_button("update")
+end
+
+When /^I have the bio "([^"]+)"$/ do |bio|
+  step %Q{I visit the settings page}
+  step %Q{I fill in the biography form with "#{bio}"}
+  step %Q{I submit the biography form}
+end
+
+Then /^I should see a link to the profile for "([^"]+)" in "([^"]+)"$/ do |user, selector|
+  within(selector) do
+    find("a[href*='#{user}']", text: "@#{user}")
+  end
+end
+
+Then /^I should see a link to "([^"]+)" in "([^"]+)"$/ do |href, selector|
+  within(selector) do
+    find("a[href='#{href}']")
+  end
+end
+
+Then /^I should( not)? see a "([^"]+)" tag in "([^"]+)"$/ do |check_absence, tagname, selector|
+  check_absence = !!check_absence
+  within(selector) do
+    tag = all(tagname)
+    if check_absence
+      assert(tag.size == 0)
+    else
+      assert(tag.size > 0)
+    end
+  end
 end

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -1,0 +1,3 @@
+Then /I should see "([^"]+)"/ do |content|
+  assert_includes(page.body, content)
+end

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -1,0 +1,3 @@
+Then /^I wait (\d+) seconds$/ do |num|
+    sleep num
+end

--- a/features/step_definitions/routing_steps.rb
+++ b/features/step_definitions/routing_steps.rb
@@ -1,3 +1,24 @@
-When /I visit the homepage/ do
+When /^I visit the homepage$/ do
   visit("/")
+end
+
+When /^I visit the signup page$/ do
+  visit("/auth/sign_up")
+end
+
+When /^I visit the user profile page for "([^"]+)"$/ do |username|
+  visit("/users/#{username}")
+end
+
+When /^I visit the settings page$/ do
+  visit("/settings/profile")
+end
+
+When /^I visit the signin page$/ do
+  visit("/auth/sign_in")
+end
+
+When /^I logout$/ do
+  step %Q{I visit the homepage}
+  click_link_or_button("sign out.")
 end

--- a/features/step_definitions/routing_steps.rb
+++ b/features/step_definitions/routing_steps.rb
@@ -1,0 +1,3 @@
+When /I visit the homepage/ do
+  visit("/")
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,24 +1,15 @@
 require "capybara/cucumber"
 require "selenium/webdriver"
 require "minitest/spec"
+require "uri"
 
-
-Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu) }
-  )
-
-  Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    desired_capabilities: capabilities
-end
-
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = :selenium_chrome_headless
 
 Capybara.configure do |config|
   config.run_server = false
-  config.default_driver = :headless_chrome
-  config.app_host = "http://localhost:8000/"
+  config.default_driver = :selenium_chrome_headless
+  config.app_host = ENV["CUCUMBER_HOST"] || "http://localhost:8000/"
+  config.ignore_hidden_elements = false
 end
 
 
@@ -33,4 +24,35 @@ end
 
 World do
   MinitestWorld.new
+end
+
+Before do
+  database_url = URI.parse(ENV["DATABASE_URL"])
+  if database_url.scheme == "postgres"
+    # We clear the database entirely between each scenario and remigrate
+    # In order to do so, we have to drop all existing connections if Postgres is
+    # currently in use.
+    database = database_url.path[1..-1]
+    drop_all_connections = <<-EOSQL
+      SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '#{database}' AND pid <> pg_backend_pid();
+    EOSQL
+    pid = spawn({
+      "PGPASS" => database_url.password,
+      "PGUSER" => database_url.user,
+      "PGHOST" => database_url.host,
+      "PGDATABASE" => database
+    }, "psql", "-c", drop_all_connections, out: "/dev/null", err: "/dev/null")
+    Process.wait(pid)
+    status = $?
+    if !status.success?
+      STDERR.puts "Failed to drop all connections, psql exit status: #{status.to_i}"
+      exit 1
+    end
+  end
+  %x{diesel database reset}
+  status = $?
+  if !status.success?
+    STDERR.puts "Failed to reset database, diesel database reset exit status: #{status.inspect}"
+    exit 1
+  end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,36 @@
+require "capybara/cucumber"
+require "selenium/webdriver"
+require "minitest/spec"
+
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu) }
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :headless_chrome
+
+Capybara.configure do |config|
+  config.run_server = false
+  config.default_driver = :headless_chrome
+  config.app_host = "http://localhost:8000/"
+end
+
+
+class MinitestWorld
+  include Minitest::Assertions
+  attr_accessor :assertions
+
+  def initialize
+    self.assertions = 0
+  end
+end
+
+World do
+  MinitestWorld.new
+end

--- a/scripts/cucumber
+++ b/scripts/cucumber
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PORT="${PORT:-"8001"}"
+DATABASE_URL="${DATABASE_URL:-"postgres://$(whoami)@localhost/rustodontest"}"
+CUCUMBER_HOST="${CUCUMBER_HOST:-"http://localhost:${PORT}/"}"
+
+env DATABASE_URL="${DATABASE_URL}" scripts/setup
+
+mkdir -p log
+env ROCKET_PORT="${PORT}" ROCKET_HOST="localhost" DATABASE_URL="${DATABASE_URL}" cargo run 2>&1 1>log/cucumber.log &
+SERVER_PROCESS=$!
+if [ "${SERVER_PROCESS}" -lt 1 ]; then
+  echo "Cannot run tests, pid < 0"
+  exit 1
+fi
+function killServerProcess() {
+ kill "${SERVER_PROCESS}"
+}
+trap killServerProcess EXIT
+trap killServerProcess INT
+bundle exec env CUCUMBER_HOST="${CUCUMBER_HOST}" DATABASE_URL="${DATABASE_URL}" DOMAIN="cucumber.domain" cucumber $@
+

--- a/scripts/setup
+++ b/scripts/setup
@@ -42,6 +42,11 @@ if ! which psql 2>/dev/null 1>&2 ; then
   exit 1
 fi
 
+if ! which chromedriver 2>/dev/null 1>&2 ; then
+  alertMsg "chromedriver is not installed, you will not be able to run the integration tests."
+  alertMsg "Install chromedriver via your package manager or the instructions at http://chromedriver.chromium.org/getting-started"
+fi
+
 # Don't track changes to .env
 git update-index --assume-unchanged .env
 

--- a/templates/edit_profile.html
+++ b/templates/edit_profile.html
@@ -7,7 +7,7 @@
     <h2>Edit your profile</h2>
 </header>
 <section>
-    <form method="post" action="/settings/profile">
+    <form method="post" action="/settings/profile" id="profile">
         <div>
             <textarea name="summary">
             {%- match account.summary %}

--- a/templates/signin.html
+++ b/templates/signin.html
@@ -7,7 +7,7 @@
     <h2>sign in</h2>
 </header>
 <section>
-    <form method="post">
+    <form method="post" id="signin">
         <div>
             <label for="username">username:</label>
             <input type="text" id="username" name="username" />

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -7,7 +7,7 @@
         <h2>sign up</h2>
     </header>
     <section>
-        <form method="post">
+        <form method="post" name="signup" id="signup">
             <div>
                 <label for="username">username:</label>
                 <input type="text" id="username" name="username" />


### PR DESCRIPTION
After #70 got merged, @ashkitten found some regressions caused by not correctly marking the content as "safe" that was being emitted by the bio transformer ( #73 ). 

This seemed like a potentially good spot for integration tests, so I've done the initial work on integrating Cucumber and writing some basic smoke tests for ensuring functionality. I've tried to stay at a high level and just capture the basics. 

The suite is configured to run with the `chromedriver` headless browser, which you can install via `brew install chromedriver` ( you may need to tap the cask for this ) or [following the official install instructions](http://chromedriver.chromium.org/getting-started).

Marked WIP due:

- [ ] Not a requested part of the app, any further work should hold until this thought desirable
- [ ] README should be adjusted with further instructions to exercise test suite
- [ ] Potentially included in Travis CI runs, configuration for same required

Functional notes:
1. The suite takes a while to run.  ( 3 min on my MBP ).
1. I had to do some slightly kludgy work to ensure the database is clean between scenarios, see `features/support/env.rb`
1. The suite is invoked via `scripts/cucumber`, as we need to ensure that the app is built, running on the expected port, and that the necessary env details are passed through before starting the actual cucumber run. Any arguments passed to `scripts/cucumber` are passed along to cucumber proper however, so individual scenarios may be run a la `scripts/cucumber path/to/the.feature:23`.