### PR TITLE
[WIP] Rewrite of entity parsing to nom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,8 +566,9 @@ name = "posticle"
 version = "0.1.0"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unic-ucd-category 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1025,6 +1026,43 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unic-char-property"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unic-char-range 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unic-common"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unic-ucd-category"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unic-char-property 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unic-char-range 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unic-ucd-version 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unic-common 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1315,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unic-char-property 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce36d3f7ce754afdbccccf8ff0dd0134e50fb44aaae579f96218856e9e5dbd1e"
+"checksum unic-char-range 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9ab85fab42ad1b26cafc03bf891f69cb4d6e15f491030e89a0122197baa8ae8"
+"checksum unic-common 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8d4a7ade929ef7d971e16ced21a8cd56a63869aa6032dfb8cb083cf7d077bf"
+"checksum unic-ucd-category 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80d28c16bf362ffb6cf46286ca1b53dcb4718bd11826abb7be7b27106ba55b9e"
+"checksum unic-ucd-version 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1f5e6c6c53c2d0ece4a5964bc55fcff8602153063cb4fab20958ff32998ff6"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"

--- a/lib/posticle/Cargo.toml
+++ b/lib/posticle/Cargo.toml
@@ -7,8 +7,9 @@ categories = ["text-processing"]
 
 [dependencies]
 lazy_static = "1.0.0"
-regex = "1.0.5"
+nom = "4.0.0"
+unic-ucd-category = "0.7.0"
 
 [dev-dependencies]
-yaml-rust = "0.4.2"
 pretty_assertions = "0.5.1"
+yaml-rust = "0.4.2"

--- a/lib/posticle/examples/cli.rs
+++ b/lib/posticle/examples/cli.rs
@@ -7,10 +7,9 @@ fn main() {
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let text = line.unwrap();
-        let entities = posticle::entities(&text);
+        let entities = posticle::entities(&text).expect("Failed entities parse");
         for entity in entities {
-            println!("entity: {:#?}", entity);
-            println!("raw text: {}", entity.substr(&text));
+            println!("entity: {:?}", entity);
         }
     }
 }

--- a/lib/posticle/src/lib.rs
+++ b/lib/posticle/src/lib.rs
@@ -1,104 +1,98 @@
 #![feature(nll)]
-extern crate regex;
-#[macro_use]
-extern crate lazy_static;
 
 #[macro_use]
+extern crate nom;
+extern crate unic_ucd_category;
+
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
 
-mod regexes;
+use nom::IResult;
 
-#[derive(Debug, PartialEq, Eq, Hash)]
-/// Tags a given [Entity]'s semantic kind.
-pub enum EntityKind {
-    /// A URL.
-    Url,
-    /// A hashtag.
-    Hashtag,
-    /// A mention; the inner data is `(username, optional domain)`.
-    Mention(String, Option<String>),
-}
+mod parsers;
 
-#[derive(Debug, PartialEq, Eq, Hash)]
 /// Represents an entity extracted from a given string of text.
 ///
-/// The entity is described by its `kind` and the `range` of indices it occupies within the string.
-pub struct Entity {
-    pub kind:  EntityKind,
-    pub range: (usize, usize),
+/// The entity is described by its semantic kind and the `data` it comprises within a string.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum Entity<'a> {
+    /// A URL.
+    Url(&'a str),
+    /// A hashtag.
+    Hashtag(&'a str),
+    /// A mention; the inner data is `(username, optional domain)`.
+    Mention(&'a str, Option<&'a str>),
 }
 
-impl Entity {
-    /// Extracts the range described by this Entity from the passed `text`.
-    pub fn substr<'a>(&self, text: &'a str) -> &'a str {
-        &text[self.range.0..self.range.1]
-    }
-
-    /// Returns `true` if this entity overlaps with some `other` entity.
-    pub fn overlaps_with(&self, other: &Entity) -> bool {
-        self.range.0 <= other.range.1 && other.range.0 <= self.range.1
-    }
+/// Represents a mix of entities and text.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum SemanticText<'a> {
+    /// Normal text.
+    Text(&'a str),
+    /// An entity.
+    Entity(Entity<'a>),
 }
 
 /// Given `text`, extract all [Entities](Entity)
-pub fn entities(text: &str) -> Vec<Entity> {
-    if text.is_empty() {
-        return Vec::new();
-    }
-
-    let mut results = extract_urls(text);
-    results.extend(extract_hashtags(text, &results));
-    results.extend(extract_mentions(text, &results));
-
-    results.sort_by(|a, b| a.range.cmp(&b.range));
-    results
-}
-
-/// Given `text`, extract all [URL](EntityKind::Url) entities.
-pub fn extract_urls(text: &str) -> Vec<Entity> {
-    regexes::RE_URL
-        .find_iter(text)
-        .map(|mat| Entity {
-            kind:  EntityKind::Url,
-            range: (mat.start(), mat.end()),
-        }).collect()
-}
-
-/// Given `text` and some `existing` entities, extract all [Hashtag](EntityKind::Hashtag) entities
-/// which do not overlap with the `existing` ones.
-pub fn extract_hashtags(text: &str, existing: &[Entity]) -> Vec<Entity> {
-    regexes::RE_HASHTAG
-        .find_iter(text)
-        .map(|mat| Entity {
-            kind:  EntityKind::Hashtag,
-            range: (mat.start(), mat.end()),
-        }).filter(|en| {
-            existing
-                .iter()
-                .all(|existing_en| !en.overlaps_with(existing_en))
-        }).collect()
-}
-
-/// Given `text` and some `existing` entities, extract all [Mention](EntityKind::Mention) entities
-/// which do not overlap with the `existing` ones.
-pub fn extract_mentions(text: &str, existing: &[Entity]) -> Vec<Entity> {
-    regexes::RE_MENTION
-        .captures_iter(text)
-        .map(|capt| {
-            let whole = capt.get(0).unwrap();
-            let user = capt[1].to_string();
-            let domain = capt.get(2).map(|s| s.as_str().to_string());
-            Entity {
-                kind:  EntityKind::Mention(user, domain),
-                range: (whole.start(), whole.end()),
+fn entities_p<'a>(text: &'a str) -> IResult<&'a str, Vec<SemanticText<'a>>> {
+    let stext: IResult<&'a str, Vec<SemanticText<'a>>>;
+    {
+        use nom::AtEof;
+        let mut res = Vec::new();
+        let mut input = text.clone();
+        let mut text_chars = 0;
+        loop {
+            let (text_input, input_) = input.split_at(text_chars);
+            match alt_complete!(
+                input_,
+                map!(parsers::valid_url, Entity::Url)
+                    | map!(parsers::hashtag, Entity::Hashtag)
+                    | map!(parsers::mention, |(u, d)| Entity::Mention(u, d))
+            ) {
+                Ok((i, o)) => {
+                    // loop trip must always consume (otherwise infinite loops)
+                    if i == input {
+                        if i.at_eof() {
+                            stext = Ok((input, res));
+                        } else {
+                            stext = Err(nom::Err::Error(error_position!(
+                                input,
+                                nom::ErrorKind::Many0
+                            )));
+                        }
+                        break;
+                    }
+                    if text_chars > 0 {
+                        res.push(SemanticText::Text(text_input));
+                        text_chars = 0;
+                    }
+                    res.push(SemanticText::Entity(o));
+                    input = i;
+                },
+                Err(nom::Err::Error(_)) => {
+                    if input_.is_empty() {
+                        if !text_input.is_empty() || !res.is_empty() {
+                            res.push(SemanticText::Text(text_input));
+                        }
+                        stext = Ok((text_input, res));
+                        break;
+                    } else {
+                        text_chars += 1;
+                    }
+                },
+                Err(e) => {
+                    stext = Err(e);
+                    break;
+                },
             }
-        }).filter(|en| {
-            existing
-                .iter()
-                .all(|existing_en| !en.overlaps_with(existing_en))
-        }).collect()
+        }
+    }
+    stext
+}
+
+pub fn entities<'a>(text: &'a str) -> Option<Vec<SemanticText<'a>>> {
+    entities_p(text).map(|r| r.1).ok()
 }
 
 #[cfg(test)]
@@ -119,14 +113,14 @@ mod tests {
         assert_eq!(
             entities("@mention"),
             vec![Entity {
-                kind:  EntityKind::Mention("mention".to_string(), None),
+                kind:  EntityKind::Mention("mention", None),
                 range: (0, 8),
             }]
         );
         assert_eq!(
             entities("@mention@domain.place"),
             vec![Entity {
-                kind:  EntityKind::Mention("mention".to_string(), Some("domain.place".to_string())),
+                kind:  EntityKind::Mention("mention", Some("domain.place")),
                 range: (0, 21),
             }]
         );
@@ -168,7 +162,7 @@ mod tests {
                     range: (9, 28),
                 },
                 Entity {
-                    kind:  EntityKind::Mention("mention".to_string(), None),
+                    kind:  EntityKind::Mention("mention", None),
                     range: (29, 37),
                 },
             ]

--- a/lib/posticle/src/parsers.rs
+++ b/lib/posticle/src/parsers.rs
@@ -1,0 +1,278 @@
+use std::cell::Cell;
+
+use nom::{digit1, IResult};
+use unic_ucd_category::GeneralCategory as GCat;
+
+fn is_invalid_char(c: char) -> bool {
+    match c as u32 {
+        0xFFFE => true,
+        0xFEFF => true,
+        0xFFFF => true,
+        0x202A..=0x202E => true,
+        _ => false,
+    }
+}
+
+fn is_punctuation_no_hyphen_underscore(c: char) -> bool {
+    match c {
+        '!' => true,
+        '"' => true,
+        '#' => true,
+        '$' => true,
+        '%' => true,
+        '&' => true,
+        '\'' => true,
+        '(' => true,
+        ')' => true,
+        '*' => true,
+        '+' => true,
+        ',' => true,
+        '.' => true,
+        '/' => true,
+        ':' => true,
+        ';' => true,
+        '<' => true,
+        '=' => true,
+        '>' => true,
+        '?' => true,
+        '@' => true,
+        '[' => true,
+        ']' => true,
+        '^' => true,
+        '`' => true,
+        '{' => true,
+        '|' => true,
+        '}' => true,
+        '~' => true,
+        _ => false,
+    }
+}
+
+fn is_punctuation(c: char) -> bool {
+    match c {
+        '-' => true,
+        '_' => true,
+        c => is_punctuation_no_hyphen_underscore(c),
+    }
+}
+
+fn is_valid_domain_extrema_char(c: char) -> bool {
+    !(is_punctuation(c) || c.is_ascii_control() || is_invalid_char(c) || c.is_whitespace())
+}
+
+fn is_valid_domain_middle_char(c: char) -> bool {
+    !(is_punctuation_no_hyphen_underscore(c)
+        || c.is_ascii_control()
+        || is_invalid_char(c)
+        || c.is_whitespace())
+}
+
+fn valid_domain_segment(i: &str) -> IResult<&str, &str> {
+    // The first and last characters can't be a hyphen or underscore.
+    // valid_domain_middle char matches hyphens and underscores, so we can manually check if we
+    // haven't seen a character yet or if we're done.
+    let prev: Cell<Option<char>> = Cell::new(None);
+    verify!(
+        i,
+        take_while!(|c| prev
+            .replace(Some(c))
+            .map_or_else(|| c == '-' || c == '_', |_| true)
+            && is_valid_domain_middle_char(c)),
+        |_| prev.get().filter(|&c| !(c == '-' || c == '_')).is_some()
+    )
+}
+
+named!(syntactically_valid_tld<&str, &str>, recognize!(do_parse!(
+    take_while_m_n!(0, 1, is_valid_domain_extrema_char) >>
+    take_while_m_n!(1, 1, |c| {
+        !(is_punctuation(c)
+            || c.is_ascii_control()
+            || is_invalid_char(c)
+            || c.is_whitespace()
+            || c.is_ascii_digit())
+    }) >>
+    opt!(alt!(
+        recognize!(tuple!(
+            take_while_m_n!(1, 60, is_valid_domain_middle_char),
+            take_while_m_n!(1, 1, is_valid_domain_extrema_char)
+        )) |
+        take_while_m_n!(1, 1, is_valid_domain_extrema_char)
+    )) >>
+    ()
+)));
+
+named!(valid_domain<&str, &str>, recognize!(tuple!(
+    separated_nonempty_list!(char!('.'), valid_domain_segment),
+    char!('.'),
+    syntactically_valid_tld
+)));
+
+fn is_valid_path_char(c: char) -> bool {
+    match c {
+        '(' => true,
+        ')' => true,
+        '<' => true,
+        '>' => true,
+        '?' => true,
+        c if c.is_whitespace() => true,
+        _ => false,
+    }
+}
+
+fn is_valid_path_ending_char(c: char) -> bool {
+    match c {
+        '!' => true,
+        '"' => true,
+        '$' => true,
+        '%' => true,
+        '&' => true,
+        '*' => true,
+        ',' => true,
+        '.' => true,
+        ':' => true,
+        ';' => true,
+        '=' => true,
+        '@' => true,
+        '[' => true,
+        '\'' => true,
+        ']' => true,
+        '|' => true,
+        '~' => true,
+        c => is_valid_path_char(c),
+    }
+}
+
+named!(valid_path_ending<&str, &str>,
+    alt!(take_while_m_n!(1, 1, is_valid_path_ending_char) | valid_path_balanced_parens)
+);
+
+named!(valid_path_balanced_parens<&str, &str>, delimited!(
+    char!('('),
+    alt!(take_while1!(is_valid_path_char) |
+         delimited!(char!('('), take_while1!(is_valid_path_char), char!(')'))),
+    char!(')')
+));
+
+named!(valid_path_segment<&str, &str>, alt!(
+    recognize!(do_parse!(
+        take_while1!(is_valid_path_char) >>
+        many0!(tuple!(valid_path_balanced_parens, take_while!(is_valid_path_char))) >>
+        valid_path_ending >>
+        ()
+    )) | recognize!(terminated!(take_while!(is_valid_path_char), char!('/')))
+));
+
+fn is_valid_query_string_char(c: char) -> bool {
+    match c {
+        '!' => true,
+        '#' => true,
+        '$' => true,
+        '%' => true,
+        '&' => true,
+        '(' => true,
+        ')' => true,
+        '*' => true,
+        '+' => true,
+        ',' => true,
+        '-' => true,
+        '.' => true,
+        '/' => true,
+        ':' => true,
+        ';' => true,
+        '=' => true,
+        '?' => true,
+        '@' => true,
+        '[' => true,
+        '\'' => true,
+        ']' => true,
+        '_' => true,
+        '|' => true,
+        '~' => true,
+        c if c.is_ascii_alphanumeric() => true,
+        _ => false,
+    }
+}
+
+fn is_valid_query_string_end_char(c: char) -> bool {
+    match c {
+        '#' => true,
+        '&' => true,
+        '-' => true,
+        '/' => true,
+        '=' => true,
+        '_' => true,
+        c if c.is_ascii_alphanumeric() => true,
+        _ => false,
+    }
+}
+
+named!(valid_query_string<&str, &str>, recognize!(tuple!(
+    take_while!(is_valid_query_string_char),
+    take_while_m_n!(1, 1, is_valid_query_string_end_char)
+)));
+
+named!(pub valid_url<&str, &str>, recognize!(do_parse!(
+    tag!("http") >> opt!(char!('s')) >> tag!("://") >>
+    valid_domain >>
+    opt!(preceded!(char!(':'), digit1)) >>
+    opt!(preceded!(char!('/'), valid_path_segment)) >>
+    opt!(preceded!(char!('?'), valid_query_string)) >>
+    ()
+)));
+
+// TODO figure out what general categories these are in
+fn is_hashtag_special_char(c: char) -> bool {
+    match c {
+        '_' => true,
+        '\u{00b7}' => true, // MIDDLE DOT
+        '\u{05be}' => true, // HEBREW PUNCTUATION MAQAF
+        '\u{05f3}' => true, // HEBREW PUNCTUATION GERESH
+        '\u{05f4}' => true, // HEBREW PUNCTUATION GERSHAYIM
+        '\u{0f0b}' => true, // TIBETAN MARK INTERSYLLABIC TSHEG
+        '\u{0f0c}' => true, // TIBETAN MARK DELIMITER TSHEG BSTAR
+        '\u{200c}' => true, // ZERO WIDTH NON-JOINER
+        '\u{200d}' => true, // ZERO WIDTH JOINER
+        '\u{3003}' => true, // DITTO MARK
+        '\u{301c}' => true, // WAVE DASH
+        '\u{309b}' => true, // KATAKANA-HIRAGANA VOICED SOUND MARK
+        '\u{309c}' => true, // KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+        '\u{30a0}' => true, // KATAKANA-HIRAGANA DOUBLE HYPHEN
+        '\u{30fb}' => true, // KATAKANA MIDDLE DOT
+        '\u{a67e}' => true, // CYRILLIC KAVYKA
+        '\u{ff5e}' => true, // FULLWIDTH TILDE
+        _ => false,
+    }
+}
+
+pub fn hashtag<'a>(i: &'a str) -> IResult<&'a str, &'a str> {
+    // Cells of parsed characters are used here due to the lack of backtracking.
+    let prev1 = Cell::new(None);
+    let prev2 = Cell::new(None);
+    preceded!(
+        i,
+        char!('#'),
+        verify!(
+            take_while!(|c| {
+                prev2.replace(prev1.replace(Some(c)));
+                is_hashtag_special_char(c) || {
+                    let cat = GCat::of(c);
+                    GCat::is_letter(&cat) || cat == GCat::DecimalNumber || GCat::is_mark(&cat)
+                }
+            }),
+            |_| prev2
+                .get()
+                .filter(|c| {
+                    let cat = GCat::of(*c);
+                    GCat::is_letter(&cat) || GCat::is_mark(&cat)
+                })
+                .is_some()
+        )
+    )
+}
+
+named!(pub mention<&str, (&str, Option<&str>)>, do_parse!(
+    char!('@') >>
+    username: take_while_m_n!(1, 32, |c: char| c.is_ascii_alphanumeric()) >>
+    domain_: opt!(preceded!(char!('@'), valid_domain)) >>
+    (username, domain_)
+));


### PR DESCRIPTION
Entity parsing is now done in one pass, instead of multiple passes. This
should be more efficient and guarantees that entities will not overlap. For notes on the current status, see the latest commit message.

Resolves #110.