### PR TITLE
Update to Rust 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,8 +72,8 @@ dependencies = [
  "askama_escape 0.1.0 (git+https://github.com/djc/askama?rev=5549f9a)",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -589,8 +589,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1072,7 +1072,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1142,8 +1142,8 @@ dependencies = [
  "rocket-slog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustodon_database 0.1.0",
- "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1214,12 +1214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1234,7 +1234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1322,7 +1322,7 @@ dependencies = [
  "new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1467,7 +1467,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1562,8 +1562,8 @@ dependencies = [
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1808,8 +1808,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)" = "c91eb5b0190ae87b4e2e39cbba6e3bed3ac6186935fe265f0426156c4c49961b"
-"checksum serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)" = "477b13b646f5b5b56fc95bedfc3b550d12141ce84f466f6c44b9a17589923885"
+"checksum serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6"
+"checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
 "checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ validator_derive = "0.8"
 
 ammonia = "1.1.0"
 
-[dependencies.rustodon_database]
+[dependencies.db]
 path = "database/"
+package = "rustodon_database"
 
 [dependencies.rocket_contrib]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustodon"
 version = "0.1.0"
 authors = ["The Rustodon team"]
+edition = "2018"
 
 [workspace]
 members = ['database/', 'lib/resopt/', 'lib/posticle/']

--- a/lib/posticle/Cargo.toml
+++ b/lib/posticle/Cargo.toml
@@ -4,6 +4,7 @@ description = "A parser and renderer for Twitter and Mastodon like text"
 version = "0.3.0"
 authors = ["Erin Moon <erin@hashbang.sh>", "Measly Twerp <measlytwerp@gmail.com>"]
 categories = ["text-processing"]
+edition = "2018"
 
 [dependencies]
 ammonia = "1.2"

--- a/lib/posticle/src/lib.rs
+++ b/lib/posticle/src/lib.rs
@@ -1,25 +1,20 @@
 //! Posticle is a parser and renderer for Twitter and Mastodon like text.
 
-#![feature(nll)]
-
-extern crate ammonia;
-#[macro_use]
-extern crate maplit;
-extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 
 pub mod grammar;
 pub mod tokens;
 
+use crate::grammar::document;
+use crate::tokens::*;
 use ammonia::Builder as Ammonia;
-use grammar::document;
-use tokens::*;
+use maplit::hashset;
 
 /// Build a new [`Reader`].
 pub struct ReaderBuilder<'t>(Reader<'t>);
 
-impl<'t> Default for ReaderBuilder<'t> {
+impl Default for ReaderBuilder<'_> {
     fn default() -> Self {
         ReaderBuilder(Reader::default())
     }
@@ -107,7 +102,7 @@ pub struct Reader<'t> {
     transformer: Box<'t + Fn(Token) -> Token>,
 }
 
-impl<'t> Default for Reader<'t> {
+impl Default for Reader<'_> {
     fn default() -> Self {
         Reader {
             input: String::new(),
@@ -118,7 +113,7 @@ impl<'t> Default for Reader<'t> {
     }
 }
 
-impl<'t> Iterator for Reader<'t> {
+impl Iterator for Reader<'_> {
     type Item = Token;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -155,7 +150,7 @@ impl<'a, 't> From<&'a str> for Reader<'t> {
     }
 }
 
-impl<'t> From<String> for Reader<'t> {
+impl From<String> for Reader<'_> {
     /// ```
     /// use posticle::tokens::*;
     /// use posticle::Reader;
@@ -174,7 +169,7 @@ impl<'t> From<String> for Reader<'t> {
     }
 }
 
-impl<'t> From<Vec<Token>> for Reader<'t> {
+impl From<Vec<Token>> for Reader<'_> {
     /// ```
     /// use posticle::tokens::*;
     /// use posticle::Reader;
@@ -204,7 +199,7 @@ impl<'ta, 'tb> PartialEq<Reader<'ta>> for Reader<'tb> {
     }
 }
 
-impl<'t> Reader<'t> {
+impl Reader<'_> {
     fn finish(self) -> Self {
         let mut tokens: Vec<Token> = Vec::new();
 
@@ -258,7 +253,7 @@ fn normalize_text_tokens(input: Vec<Token>) -> Vec<Token> {
 
 pub struct WriterBuilder<'w>(Writer<'w>);
 
-impl<'w> Default for WriterBuilder<'w> {
+impl Default for WriterBuilder<'_> {
     fn default() -> Self {
         WriterBuilder(Writer::default())
     }
@@ -359,7 +354,7 @@ pub struct Writer<'w> {
     tokens: Vec<Token>,
 }
 
-impl<'w> Default for Writer<'w> {
+impl Default for Writer<'_> {
     fn default() -> Self {
         let mut html_sanitizer = Ammonia::default();
 
@@ -390,7 +385,7 @@ impl<'w, 't> From<Reader<'t>> for Writer<'w> {
     }
 }
 
-impl<'w> From<Vec<Token>> for Writer<'w> {
+impl From<Vec<Token>> for Writer<'_> {
     /// ```
     /// use posticle::tokens::*;
     /// use posticle::Writer;
@@ -406,7 +401,7 @@ impl<'w> From<Vec<Token>> for Writer<'w> {
     }
 }
 
-impl<'w> Writer<'w> {
+impl Writer<'_> {
     fn finish(mut self) -> Self {
         for token in self.tokens.to_owned() {
             self.push(&token);

--- a/lib/posticle/src/tokens.rs
+++ b/lib/posticle/src/tokens.rs
@@ -1,4 +1,4 @@
-use grammar::Rule;
+use crate::grammar::Rule;
 use pest::iterators::Pair;
 
 fn html_escape(text: &str) -> String {

--- a/lib/resopt/Cargo.toml
+++ b/lib/resopt/Cargo.toml
@@ -3,5 +3,6 @@ name = "resopt"
 description = "Tools for working with Result<Option<T>>"
 version = "0.1.0"
 authors = ["Erin <erin@hashbang.sh>"]
+edition = "2018"
 
 [dependencies]

--- a/lib/resopt/src/lib.rs
+++ b/lib/resopt/src/lib.rs
@@ -3,14 +3,14 @@
 macro_rules! try_resopt {
     ($expr:expr) => {
         match $expr {
-            ::std::result::Result::Ok(opt_val) => match opt_val {
-                ::std::option::Option::Some(val) => val,
-                ::std::option::Option::None => {
-                    return ::std::result::Result::Ok(::std::option::Option::None);
+            std::result::Result::Ok(opt_val) => match opt_val {
+                std::option::Option::Some(val) => val,
+                std::option::Option::None => {
+                    return std::result::Result::Ok(std::option::Option::None);
                 },
             },
-            ::std::result::Result::Err(err) => {
-                return ::std::result::Result::Err(::std::convert::From::from(err));
+            std::result::Result::Err(err) => {
+                return std::result::Result::Err(std::convert::From::from(err));
             },
         }
     };

--- a/src/activitypub/mod.rs
+++ b/src/activitypub/mod.rs
@@ -1,12 +1,11 @@
-use db;
+use crate::routes::ui::view_helpers::HasBio;
 use db::models::{Account, Status};
 use failure::Error;
 use rocket::http::{self, Accept, ContentType, MediaType};
 use rocket::request::{self, FromRequest, Request};
 use rocket::response::{self, Content, Responder};
-use crate::routes::ui::view_helpers::HasBio;
 use serde::Serialize;
-use serde_json::{self, Value};
+use serde_json::{json, Value};
 
 /// Newtype for JSON which represents JSON-LD ActivityStreams2 objects.
 ///

--- a/src/activitypub/mod.rs
+++ b/src/activitypub/mod.rs
@@ -4,7 +4,7 @@ use failure::Error;
 use rocket::http::{self, Accept, ContentType, MediaType};
 use rocket::request::{self, FromRequest, Request};
 use rocket::response::{self, Content, Responder};
-use routes::ui::view_helpers::HasBio;
+use crate::routes::ui::view_helpers::HasBio;
 use serde::Serialize;
 use serde_json::{self, Value};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,3 @@
 /// A type which could be nonexistent, existent, or errored;
 /// used for routes which might return {something, a 404, a 500}.
-pub type Perhaps<T> = Result<Option<T>, ::failure::Error>;
+pub type Perhaps<T> = Result<Option<T>, failure::Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(nll, custom_derive, proc_macro_hygiene, decl_macro)]
+#![feature(nll, proc_macro_hygiene, decl_macro)]
 #![recursion_limit = "128"]
 // Allow some clippy lints that would otherwise warn on various Rocket-generated code.
 // Unfortunately, this means we lose these lints on _our_ code, but it's a small price to pay

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,61 +1,29 @@
-#![feature(nll, proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene, decl_macro)]
 #![recursion_limit = "128"]
 // Allow some clippy lints that would otherwise warn on various Rocket-generated code.
 // Unfortunately, this means we lose these lints on _our_ code, but it's a small price to pay
 // for less line noise running `cargo clippy`.
 #![allow(clippy::needless_pass_by_value, clippy::suspicious_else_formatting)]
 
-extern crate ammonia;
-extern crate chrono;
-extern crate dotenv;
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
-extern crate itertools;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate resopt;
 #[macro_use]
 extern crate rocket;
-extern crate rocket_contrib;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate serde_json;
-extern crate validator;
 #[macro_use]
 extern crate validator_derive;
-#[macro_use]
-extern crate maplit;
-extern crate posticle;
-extern crate regex;
-#[macro_use(slog_o, slog_warn)]
-extern crate slog;
-extern crate slog_async;
-extern crate slog_term;
-#[macro_use]
-extern crate slog_scope;
-extern crate rocket_slog;
 
-extern crate rustodon_database as db;
-
-#[macro_use]
-mod error;
 mod activitypub;
+mod error;
 mod routes;
 mod transform;
 mod util;
 
 use dotenv::dotenv;
+use lazy_static::lazy_static;
 use rocket::config::Config;
 use rocket_slog::SlogFairing;
 use slog::Drain;
+use slog::{slog_o, slog_warn};
+use slog_scope::warn;
 use std::env;
-
-#[macro_use]
-extern crate askama;
 
 lazy_static! {
     pub static ref BASE_URL: String = format!(

--- a/src/routes/ap.rs
+++ b/src/routes/ap.rs
@@ -1,9 +1,9 @@
 use rocket::Route;
 
-use activitypub::{ActivityGuard, ActivityStreams, AsActivityPub};
+use crate::activitypub::{ActivityGuard, ActivityStreams, AsActivityPub};
 use db;
 use db::models::{Account, Status};
-use error::Perhaps;
+use crate::error::Perhaps;
 
 pub fn routes() -> Vec<Route> {
     routes![ap_user_object, ap_status_object,]

--- a/src/routes/ap.rs
+++ b/src/routes/ap.rs
@@ -1,9 +1,9 @@
+use resopt::try_resopt;
 use rocket::Route;
 
 use crate::activitypub::{ActivityGuard, ActivityStreams, AsActivityPub};
-use db;
-use db::models::{Account, Status};
 use crate::error::Perhaps;
+use db::models::{Account, Status};
 
 pub fn routes() -> Vec<Route> {
     routes![ap_user_object, ap_status_object,]

--- a/src/routes/ui/auth.rs
+++ b/src/routes/ui/auth.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use rocket::http::{Cookie, Cookies};
 use rocket::request::{FlashMessage, Form};
 use rocket::response::{Flash, Redirect};
-use routes::ui::templates::{SigninTemplate, SignupTemplate};
+use crate::routes::ui::templates::{SigninTemplate, SignupTemplate};
 use std::borrow::Cow;
 use validator::Validate;
 

--- a/src/routes/ui/auth.rs
+++ b/src/routes/ui/auth.rs
@@ -1,12 +1,12 @@
+use crate::routes::ui::templates::{SigninTemplate, SignupTemplate};
 use db::models::{NewAccount, NewUser, User};
 use db::validators;
-use db::{self, id_generator, DieselConnection, LOCAL_ACCOUNT_DOMAIN};
+use db::{id_generator, DieselConnection, LOCAL_ACCOUNT_DOMAIN};
 use failure::Error;
 use itertools::Itertools;
 use rocket::http::{Cookie, Cookies};
 use rocket::request::{FlashMessage, Form};
 use rocket::response::{Flash, Redirect};
-use crate::routes::ui::templates::{SigninTemplate, SignupTemplate};
 use std::borrow::Cow;
 use validator::Validate;
 

--- a/src/routes/ui/mod.rs
+++ b/src/routes/ui/mod.rs
@@ -1,7 +1,7 @@
 use chrono::offset::Utc;
 use db::models::{Account, NewStatus, Status, User};
 use db::{self, id_generator};
-use error::Perhaps;
+use crate::error::Perhaps;
 use failure::Error;
 use itertools::Itertools;
 use rocket::http::RawStr;
@@ -10,7 +10,7 @@ use rocket::response::{Flash, NamedFile, Redirect};
 use rocket::Route;
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
-use util::Either;
+use crate::util::Either;
 use validator::Validate;
 
 #[macro_use]

--- a/src/routes/ui/mod.rs
+++ b/src/routes/ui/mod.rs
@@ -1,16 +1,17 @@
-use chrono::offset::Utc;
-use db::models::{Account, NewStatus, Status, User};
-use db::{self, id_generator};
 use crate::error::Perhaps;
+use crate::util::Either;
+use chrono::offset::Utc;
+use db::id_generator;
+use db::models::{Account, NewStatus, Status, User};
 use failure::Error;
 use itertools::Itertools;
+use resopt::try_resopt;
 use rocket::http::RawStr;
 use rocket::request::{FlashMessage, Form, FromFormValue};
 use rocket::response::{Flash, NamedFile, Redirect};
 use rocket::Route;
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
-use crate::util::Either;
 use validator::Validate;
 
 #[macro_use]
@@ -176,8 +177,7 @@ pub fn settings_profile_update(
 ) -> Result<Redirect, Error> {
     let account = user.get_account(&db_conn)?;
 
-    // `as &str` defeat an incorrect deref coercion (due to the second match arm)
-    let new_summary = match &form.summary as &str {
+    let new_summary = match &form.summary[..] {
         "" => None,
         x => Some(x.to_string()),
     };

--- a/src/routes/ui/templates.rs
+++ b/src/routes/ui/templates.rs
@@ -1,8 +1,7 @@
+use crate::routes::ui::view_helpers::*;
 use askama::Template;
-use db;
 use db::models::{Account, Status};
 use rocket::request::FlashMessage;
-use crate::routes::ui::view_helpers::*;
 
 macro_rules! HtmlTemplate {
     ($x:tt) => {{

--- a/src/routes/ui/templates.rs
+++ b/src/routes/ui/templates.rs
@@ -2,7 +2,7 @@ use askama::Template;
 use db;
 use db::models::{Account, Status};
 use rocket::request::FlashMessage;
-use routes::ui::view_helpers::*;
+use crate::routes::ui::view_helpers::*;
 
 macro_rules! HtmlTemplate {
     ($x:tt) => {{

--- a/src/routes/ui/view_helpers.rs
+++ b/src/routes/ui/view_helpers.rs
@@ -1,7 +1,6 @@
-use db;
+use crate::transform;
 use db::models::Account;
 use failure::Error;
-use crate::transform;
 
 pub trait HasBio {
     fn transformed_bio(&self, connection: &db::Connection) -> Option<String>;

--- a/src/routes/ui/view_helpers.rs
+++ b/src/routes/ui/view_helpers.rs
@@ -1,7 +1,7 @@
 use db;
 use db::models::Account;
 use failure::Error;
-use transform;
+use crate::transform;
 
 pub trait HasBio {
     fn transformed_bio(&self, connection: &db::Connection) -> Option<String>;

--- a/src/routes/well_known.rs
+++ b/src/routes/well_known.rs
@@ -7,8 +7,8 @@ use rocket_contrib::json::JsonValue;
 
 use db;
 use db::models::{Account, Status, User};
-use error::Perhaps;
-use {BASE_URL, DOMAIN, GIT_REV};
+use crate::error::Perhaps;
+use crate::{BASE_URL, DOMAIN, GIT_REV};
 
 pub fn routes() -> Vec<Route> {
     routes![

--- a/src/routes/well_known.rs
+++ b/src/routes/well_known.rs
@@ -1,14 +1,15 @@
 use failure::Error;
 use itertools::Itertools;
+use resopt::try_resopt;
 use rocket::http::ContentType;
 use rocket::response::Content;
 use rocket::Route;
 use rocket_contrib::json::JsonValue;
+use serde_json::json;
 
-use db;
-use db::models::{Account, Status, User};
 use crate::error::Perhaps;
 use crate::{BASE_URL, DOMAIN, GIT_REV};
+use db::models::{Account, Status, User};
 
 pub fn routes() -> Vec<Route> {
     routes![

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -5,7 +5,7 @@ use posticle::{ReaderBuilder, WriterBuilder};
 use regex::Regex;
 
 use db::models::Account;
-use error::Perhaps;
+use crate::error::Perhaps;
 
 lazy_static! {
     /// Matches all valid characters in a hashtag name (after the first #).

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,11 +1,13 @@
 use ammonia::{Builder, Url};
 use failure::Error;
+use lazy_static::lazy_static;
+use maplit::hashset;
 use posticle::tokens::*;
 use posticle::{ReaderBuilder, WriterBuilder};
 use regex::Regex;
 
-use db::models::Account;
 use crate::error::Perhaps;
+use db::models::Account;
 
 lazy_static! {
     /// Matches all valid characters in a hashtag name (after the first #).


### PR DESCRIPTION
Fixes #139.

The compiler also said that the `custom_derive` feature was removed and subsumed by `#[proc_macro_derive]`, but it compiled fine without the attribute. Do I leave it out or should I place it somewhere?