### PR TITLE
db: nothing but routes should take the db::Connection guard as an arg

### DIFF
--- a/src/activitypub/mod.rs
+++ b/src/activitypub/mod.rs
@@ -72,13 +72,13 @@ fn is_as(accept: &Accept) -> bool {
 /// Trait implemented by structs which can serialize to
 /// ActivityPub-compliant ActivityStreams2 JSON-LD.
 pub trait AsActivityPub {
-    fn as_activitypub(&self, db: &db::Connection) -> Result<ActivityStreams, Error>;
+    fn as_activitypub(&self, db: &db::DbConnection) -> Result<ActivityStreams, Error>;
 }
 
 impl AsActivityPub for Account {
     fn as_activitypub(
         &self,
-        conn: &db::Connection,
+        conn: &db::DbConnection,
     ) -> Result<ActivityStreams<serde_json::Value>, Error> {
         Ok(ActivityStreams(json!({
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -101,7 +101,7 @@ impl AsActivityPub for Account {
 impl AsActivityPub for Status {
     fn as_activitypub(
         &self,
-        conn: &db::Connection,
+        conn: &db::DbConnection,
     ) -> Result<ActivityStreams<serde_json::Value>, Error> {
         let account = self.account(conn)?;
         Ok(ActivityStreams(json!({

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -19,18 +19,21 @@ pub use self::idgen::id_generator;
 
 pub static LOCAL_ACCOUNT_DOMAIN: &'static str = "";
 
+/// The raw database connection type. Aliased so it's easy to switch when using, eg, an sqlite backend.
+pub type DbConnection = PgConnection;
+
 /// Convenient type alias for the postgres database pool so we don't have to type this out.
-pub type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
+pub type Pool = r2d2::Pool<ConnectionManager<DbConnection>>;
 
 /// Type alias for the pooled connection.
-pub type PooledConnection = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
+pub type PooledConnection = r2d2::PooledConnection<ConnectionManager<DbConnection>>;
 
 /// Initializes a new connection pool for the database at `url`.
 pub fn init_connection_pool<S>(url: S) -> Result<Pool, r2d2::PoolError>
 where
     S: Into<String>,
 {
-    let manager = ConnectionManager::<PgConnection>::new(url);
+    let manager = ConnectionManager::<DbConnection>::new(url);
 
     r2d2::Pool::builder().build(manager)
 }
@@ -58,11 +61,11 @@ impl<'a, 'r> FromRequest<'a, 'r> for Connection {
     }
 }
 
-/// A convenient way to use a `&db::Connection` as a `&PgConnection`.
+/// A convenient way to use a `&db::Connection` as a `&DbConnection`.
 ///
 /// Just allows deref-ing the inner `PooledConnection`.
 impl Deref for Connection {
-    type Target = PgConnection;
+    type Target = DbConnection;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/db/models/status.rs
+++ b/src/db/models/status.rs
@@ -1,4 +1,4 @@
-use crate::db::Connection;
+use crate::db::DbConnection;
 use crate::BASE_URL;
 use chrono::offset::Utc;
 use chrono::DateTime;
@@ -37,27 +37,25 @@ pub struct NewStatus {
 }
 
 impl NewStatus {
-    pub fn insert(self, conn: &Connection) -> QueryResult<Status> {
+    pub fn insert(self, conn: &DbConnection) -> QueryResult<Status> {
         use crate::db::schema::statuses::dsl::*;
 
-        diesel::insert_into(statuses)
-            .values(&self)
-            .get_result(&**conn)
+        diesel::insert_into(statuses).values(&self).get_result(conn)
     }
 }
 
 impl Status {
     /// Returns the `Account` which authored this status.
-    pub fn account(&self, db_conn: &Connection) -> QueryResult<Account> {
+    pub fn account(&self, db_conn: &DbConnection) -> QueryResult<Account> {
         use crate::db::schema::accounts::dsl;
         dsl::accounts
             .find(self.account_id)
-            .first::<Account>(&**db_conn)
+            .first::<Account>(db_conn)
     }
 
     /// Returns an optional status given an account ID and a status ID.
     pub fn by_account_and_id(
-        db_conn: &Connection,
+        db_conn: &DbConnection,
         account_id: i64,
         id: i64,
     ) -> QueryResult<Option<Status>> {
@@ -65,21 +63,21 @@ impl Status {
         dsl::statuses
             .find(id)
             .filter(dsl::account_id.eq(account_id))
-            .first::<Status>(&**db_conn)
+            .first::<Status>(db_conn)
             .optional()
     }
 
     /// Returns the number of local statuses
-    pub fn count_local(db_conn: &Connection) -> QueryResult<i64> {
+    pub fn count_local(db_conn: &DbConnection) -> QueryResult<i64> {
         use crate::db::schema::statuses::dsl::{statuses, uri};
         statuses
             .filter(uri.is_null()) // is local status
             .count()
-            .get_result(&**db_conn)
+            .get_result(db_conn)
     }
 
     /// Returns a URI to the ActivityPub object of this status.
-    pub fn get_uri(&self, db_conn: &Connection) -> QueryResult<Cow<'_, str>> {
+    pub fn get_uri(&self, db_conn: &DbConnection) -> QueryResult<Cow<'_, str>> {
         let account = self.account(db_conn)?;
         Ok(self.uri_with_account(&account))
     }
@@ -91,7 +89,7 @@ impl Status {
 
     /// Returns `n` local statuses which were authored _strictly before_ the status `max_id`.
     pub fn local_before_id(
-        db_conn: &Connection,
+        db_conn: &DbConnection,
         max_id: Option<i64>,
         n: usize,
     ) -> QueryResult<Vec<Status>> {
@@ -106,13 +104,13 @@ impl Status {
         query
             .order(dsl::id.desc())
             .limit(n as i64)
-            .get_results::<Status>(&**db_conn)
+            .get_results::<Status>(db_conn)
     }
 
     /// Returns `n` statuses in the database, authored _strictly before_ the
     /// status `max_id`.
     pub fn federated_before_id(
-        db_conn: &Connection,
+        db_conn: &DbConnection,
         max_id: Option<i64>,
         n: usize,
     ) -> QueryResult<Vec<Status>> {
@@ -127,14 +125,14 @@ impl Status {
         query
             .order(dsl::id.desc())
             .limit(n as i64)
-            .get_results::<Status>(&**db_conn)
+            .get_results::<Status>(db_conn)
     }
 
     /// Returns a tuple of upper and lower bounds on the IDs of statuses authored locally
     /// (i.e., `min(ids)` and `max(ids)` where `ids` is a list of status ids authored locally).
     ///
     /// If there are no local statuses in the database, return `None`.
-    pub fn local_status_id_bounds(db_conn: &Connection) -> QueryResult<Option<(i64, i64)>> {
+    pub fn local_status_id_bounds(db_conn: &DbConnection) -> QueryResult<Option<(i64, i64)>> {
         use crate::db::schema::statuses::dsl::*;
         use diesel::dsl::sql;
         // Yes, this is gross and we don't like having to use sql() either.
@@ -142,7 +140,7 @@ impl Status {
         statuses
             .select((sql("min(id)"), sql("max(id)")))
             .filter(uri.is_null())
-            .first::<(Option<i64>, Option<i64>)>(&**db_conn)
+            .first::<(Option<i64>, Option<i64>)>(db_conn)
             .map(|result| match result {
                 (Some(x), Some(y)) => Some((x, y)),
                 _ => None,
@@ -153,14 +151,14 @@ impl Status {
     /// (i.e., `min(ids)` and `max(ids)` where `ids` is a list of status ids).
     ///
     /// If there are no statuses in the database, return `None`.
-    pub fn federated_status_id_bounds(db_conn: &Connection) -> QueryResult<Option<(i64, i64)>> {
+    pub fn federated_status_id_bounds(db_conn: &DbConnection) -> QueryResult<Option<(i64, i64)>> {
         use crate::db::schema::statuses::dsl::*;
         use diesel::dsl::sql;
         // Yes, this is gross and we don't like having to use sql() either.
         // See [diesel-rs/diesel#3](https://github.com/diesel-rs/diesel/issues/3) for why this is necessary.
         statuses
             .select((sql("min(id)"), sql("max(id)")))
-            .first::<(Option<i64>, Option<i64>)>(&**db_conn)
+            .first::<(Option<i64>, Option<i64>)>(db_conn)
             .map(|result| match result {
                 (Some(x), Some(y)) => Some((x, y)),
                 _ => None,

--- a/src/routes/ui/view_helpers.rs
+++ b/src/routes/ui/view_helpers.rs
@@ -4,11 +4,11 @@ use crate::transform;
 use failure::Error;
 
 pub trait HasBio {
-    fn transformed_bio(&self, connection: &db::Connection) -> Option<String>;
+    fn transformed_bio(&self, connection: &db::DbConnection) -> Option<String>;
 }
 
 impl HasBio for Account {
-    fn transformed_bio(&self, connection: &db::Connection) -> Option<String> {
+    fn transformed_bio(&self, connection: &db::DbConnection) -> Option<String> {
         if let Some(raw_bio) = self.summary.as_ref().map(String::as_str) {
             transform::bio(raw_bio, |username, domain| {
                 Account::fetch_by_username_domain(connection, username, domain).map_err(Error::from)


### PR DESCRIPTION
there is no point in passing the guard around because we have to then do the silly `&*` deref trick when using it! everything should just take `&PgConnection` (here, type-aliased to `&db::DbConnection`). autoderefs will occur so we don't need to change any code other than switching from `Connection` to `DbConnection` and dropping the deref hacks. this also makes testing individual subsystems easier :)

also, this brings our total of deref hacks down to one:
```
λ ~/git/rustodon  
» ag -Q '&*'
src/routes/ui/mod.rs
132:    diesel::delete(&status).execute(&*db_conn)?;
```