### PR TITLE
Clippy cleanup

### DIFF
--- a/src/activitypub/mod.rs
+++ b/src/activitypub/mod.rs
@@ -7,6 +7,8 @@ use rocket::request::{self, FromRequest, Request};
 use rocket::response::{self, Content, Responder};
 use serde::Serialize;
 use serde_json::{json, Value};
+use slog::slog_error;
+use slog_scope::error;
 
 /// Newtype for JSON which represents JSON-LD ActivityStreams2 objects.
 ///
@@ -25,8 +27,8 @@ where
                 Content(ap_json, string).respond_to(req).unwrap()
             })
             .map_err(|e| {
-                // TODO: logging (what happens if the Value won't serialize?)
-                // the code i cribbed this from did some internal Rocket thing.
+                error!("Failed to serialize ActivityStreams2 content: {:?}", e);
+
                 http::Status::InternalServerError
             })
     }

--- a/src/db/idgen.rs
+++ b/src/db/idgen.rs
@@ -47,6 +47,7 @@ fn node_id() -> u64 {
 }
 
 impl IdGenerator {
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> i64 {
         self.flaken.next() as i64
     }

--- a/src/db/models/account.rs
+++ b/src/db/models/account.rs
@@ -116,7 +116,7 @@ impl Account {
     }
 
     /// Returns the URI of the account's ActivityPub object.
-    pub fn get_uri<'a>(&'a self) -> Cow<'a, str> {
+    pub fn get_uri(&self) -> Cow<'_, str> {
         self.uri
             .as_ref()
             .map(|x| String::as_str(x).into())
@@ -131,12 +131,12 @@ impl Account {
     }
 
     /// Returns the server local path to the Account profile page for this account.
-    pub fn profile_path<'a>(&'a self) -> Cow<'a, str> {
+    pub fn profile_path(&self) -> Cow<'_, str> {
         format!("/users/{user}", user = self.username).into()
     }
 
     /// Returns the URI of the ActivityPub `inbox` endpoint for this account.
-    pub fn get_inbox_endpoint<'a>(&'a self) -> Cow<'a, str> {
+    pub fn get_inbox_endpoint(&self) -> Cow<'_, str> {
         self.uri
             .as_ref()
             .map(|x| String::as_str(x).into())
@@ -151,12 +151,12 @@ impl Account {
     }
 
     /// Returns the server local path to the `inbox` endpoint for this account.
-    pub fn inbox_path<'a>(&'a self) -> Cow<'a, str> {
+    pub fn inbox_path(&self) -> Cow<'_, str> {
         format!("/users/{user}/inbox", user = self.username).into()
     }
 
     /// Returns the URI of the ActivityPub `outbox` endpoint for this account.
-    pub fn get_outbox_endpoint<'a>(&'a self) -> Cow<'a, str> {
+    pub fn get_outbox_endpoint(&self) -> Cow<'_, str> {
         self.uri
             .as_ref()
             .map(|x| String::as_str(x).into())
@@ -171,12 +171,12 @@ impl Account {
     }
 
     /// Returns the server local path to the `outbox` endpoint for this account.
-    pub fn outbox_path<'a>(&'a self) -> Cow<'a, str> {
+    pub fn outbox_path(&self) -> Cow<'_, str> {
         format!("/users/{user}/outbox", user = self.username).into()
     }
 
     /// Returns the URI of the ActivityPub `following` endpoint for this account.
-    pub fn get_following_endpoint<'a>(&'a self) -> Cow<'a, str> {
+    pub fn get_following_endpoint(&self) -> Cow<'_, str> {
         self.uri
             .as_ref()
             .map(|x| String::as_str(x).into())
@@ -191,12 +191,12 @@ impl Account {
     }
 
     /// Returns the server local path to the `following` endpoint for this account.
-    pub fn following_path<'a>(&'a self) -> Cow<'a, str> {
+    pub fn following_path(&self) -> Cow<'_, str> {
         format!("/users/{user}/following", user = self.username).into()
     }
 
     /// Returns the URI of the ActivityPub `followers` endpoint for this account.
-    pub fn get_followers_endpoint<'a>(&'a self) -> Cow<'a, str> {
+    pub fn get_followers_endpoint(&self) -> Cow<'_, str> {
         self.uri
             .as_ref()
             .map(|x| String::as_str(x).into())
@@ -211,7 +211,7 @@ impl Account {
     }
 
     /// Returns the server local path to the `followers` resource on this account.
-    pub fn followers_path<'a>(&'a self) -> Cow<'a, str> {
+    pub fn followers_path(&self) -> Cow<'_, str> {
         format!("/users/{user}/followers", user = self.username).into()
     }
 

--- a/src/db/models/status.rs
+++ b/src/db/models/status.rs
@@ -79,7 +79,7 @@ impl Status {
     }
 
     /// Returns a URI to the ActivityPub object of this status.
-    pub fn get_uri<'a>(&'a self, db_conn: &'a Connection) -> QueryResult<Cow<'a, str>> {
+    pub fn get_uri(&self, db_conn: &Connection) -> QueryResult<Cow<'_, str>> {
         let account = self.account(db_conn)?;
         Ok(self.uri_with_account(&account))
     }


### PR DESCRIPTION
- elide some explicit lifetimes
- stop clippy from linting `IdGenerator::next()` method as something that should `impl Iterator` for best ergonomics (it shouldn't)
- log an error if the `ActivityStreams` guard fails to serialize