### PR TITLE
structopt 0.2.17 → 0.2.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ failure_derive = "0.1.5"
 lazy_static = "1.3"
 itertools = "0.8.0"
 resopt = { path = "lib/resopt/" }
-structopt = "0.2.17"
+structopt = "0.2.16"
 
 regex = "1.1.7"
 posticle = { path = "lib/posticle/" }


### PR DESCRIPTION
Dependabot failed after structopt 0.2.17 got yanked from Crates.io.