### PR TITLE
Add systemd service for rustodon (#135)

### DIFF
--- a/scripts/default_rustodon
+++ b/scripts/default_rustodon
@@ -1,0 +1,3 @@
+ROCKET_ENV=development
+DAEMON_OPTS=run
+

--- a/scripts/rustodon.service
+++ b/scripts/rustodon.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Rustodon ActivityPub compatible micro-blogging
+After=network.target
+ConditionPathExists=/srv/rustodon/.env
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/default/rustodon
+WorkingDirectory=/srv/rustodon
+ExecStart=/srv/rustodon/target/release/rustodon -- $DAEMON_OPTS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
In service file, assume Rustodon instance is deployed in /srv/rustodon.
Include an /etc/default/rustodon environment file to define required Rocket env.

Variables in `/srv/rustodon/.env` may be moved in `/etc/default/rustodon`.

See full commit message for usage.

This is my systemd service file I use in may VPS.

Regards,
David