### PR TITLE
Remove the format specifier for /nodeinfo/2.0 route (#272)

### DIFF
--- a/src/routes/well_known.rs
+++ b/src/routes/well_known.rs
@@ -91,7 +91,7 @@ pub fn webfinger_nodeinfo() -> Content<JsonValue> {
     Content(jrd_ctype, JsonValue(doc))
 }
 
-#[get("/nodeinfo/2.0", format = "application/json")]
+#[get("/nodeinfo/2.0")]
 pub fn nodeinfo(db_conn: db::Connection) -> Result<Content<JsonValue>, Error> {
     let ctype = ContentType::with_params(
         "application",


### PR DESCRIPTION
This allow using Firefox or any browser to retreive node information.

With this format specifier, Rocket will route FF request to `/<username>/<status_id>`
because FF add the `Accept: text/html` in it's request headers.

Closes #272.